### PR TITLE
Add redirect for creating a wallet

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -89,3 +89,4 @@ redirects:
     v1/developers/phat-contract/features: developers/phat-contract/features.md
     v1/developers/phat-contract/bricks-and-blueprints: developers/phat-contract/bricks-and-blueprints.md
     v1/developers/phat-contract: developers/phat-contract/README.md
+    en-us/general/applications/extension-wallet/: introduction/basic-guidance/README.md


### PR DESCRIPTION
Fix redirect that is seen in the Phat Bricks UI here:
![redirect-error](https://github.com/Phala-Network/phala-docs/assets/64296537/e6a01d5d-1544-45ec-b174-8478fecc8666)
