### PR TITLE
Fix Incorrect Base URL in Confidential AI API Examples (Python & TypeScript)

### DIFF
--- a/phala-cloud/confidential-ai/confidential-model/confidential-ai-api.mdx
+++ b/phala-cloud/confidential-ai/confidential-model/confidential-ai-api.mdx
@@ -30,7 +30,7 @@ Replace `<API_KEY>` with your actual API key in the examples below. We use DeepS
 
 from openai import OpenAI
 
-client = OpenAI(api_key="<API_KEY>", base_url="https://api.redpill.ai/api/v1")
+client = OpenAI(api_key="<API_KEY>", base_url="https://api.redpill.ai/v1")
 
 response = client.chat.completions.create(
     model="phala/deepseek-chat-v3-0324",
@@ -47,7 +47,7 @@ print(response.choices[0].message.content)
 import OpenAI from 'openai';
 
 const client = new OpenAI({
-    baseURL: 'https://api.redpill.ai/api/v1',
+    baseURL: 'https://api.redpill.ai/v1',
     apiKey: '<API_KEY>',
   },
 });


### PR DESCRIPTION
# Fix Incorrect Base URL in Confidential AI API Examples (Python & TypeScript)

## Summary
This pull request corrects the API base URL in both the **Python** and **TypeScript** code examples on the Confidential AI API documentation page. The previous examples used an incorrect endpoint (`https://api.redpill.ai/api/v1`) which results in a `404 Not Found` error. The correct base URL is `https://api.redpill.ai/v1`, as confirmed via direct API testing.

## Changes Made
Corrected Base URL from `https://api.redpill.ai/api/v1` ➝ `https://api.redpill.ai/v1`

## Reasoning
Using the incorrect endpoint leads to failed API requests and confusion for developers integrating Confidential AI. The corrected endpoint has been verified using:
```bash
curl -I https://api.redpill.ai/v1/chat/completions   # Returns 400 (valid endpoint, missing body)
curl -I https://api.redpill.ai/api/v1/chat/completions  # Returns 404 (invalid path)