### PR TITLE
Update Rust section header level

### DIFF
--- a/dstack/local-development.mdx
+++ b/dstack/local-development.mdx
@@ -249,7 +249,7 @@ func main() {
 }
 ```
 
-#### Rust
+### Rust
 
 Check the latest version in [dstack](https://github.com/Dstack-TEE/dstack/tree/master/sdk/rust) code repository.
 


### PR DESCRIPTION
Change header from '####' to '###' for Rust section.

fixes #108 