### PR TITLE
docs: standardize dstack terminology

### DIFF
--- a/phala-cloud/attestation/api-quickstart.mdx
+++ b/phala-cloud/attestation/api-quickstart.mdx
@@ -69,7 +69,7 @@ curl "https://cloud-api.phala.network/api/v1/attestations/view/9aa049fb9049d4f58
 ### Next Steps
 
 - **Complete API Reference** - [All endpoints and parameters](/phala-cloud/phala-cloud-api/attestations)
-- **Generate Your Own Quotes** - [DStack SDK integration](/phala-cloud/attestation/get-attestation)  
+- **Generate Your Own Quotes** - [dstack SDK integration](/phala-cloud/attestation/get-attestation)  
 - **Understand the Data** - [What attestation fields mean](/phala-cloud/attestation/overview)
 
 ### Quick Troubleshooting

--- a/phala-cloud/attestation/get-attestation.mdx
+++ b/phala-cloud/attestation/get-attestation.mdx
@@ -1,5 +1,5 @@
 ---
-description: Generate Intel SGX and TDX attestation quotes using DStack SDK and Phala Cloud platform
+description: Generate Intel SGX and TDX attestation quotes using dstack SDK and Phala Cloud platform
 title: Generate Attestation
 ---
 

--- a/phala-cloud/attestation/trust-center-verification.mdx
+++ b/phala-cloud/attestation/trust-center-verification.mdx
@@ -117,7 +117,7 @@ This verification confirms the OS running in your TEE matches a known trusted ve
 - **RTMR0**: Virtual hardware environment measurement
 - **RTMR1**: Linux kernel measurement
 - **RTMR2**: Kernel command line and initrd measurement
-- **Dstack Version**: Specific OS image version hash
+- **dstack Version**: Specific OS image version hash
 
 **Why it matters**: Proves the operating system hasn't been modified or backdoored. The OS matches publicly auditable dstack releases.
 
@@ -151,7 +151,7 @@ This section verifies that cryptographic keys are properly managed and derived t
 - **KMS Node TEE Status**: All KMS nodes run in TEE environments with program digests matching the smart contract
 - **App-ID Binding**: Confirms keys are uniquely derived from your application identifier
 - **Key Derivation Protocol**: Validates the cryptographic protocol used to generate encryption keys
-- **No Vendor Lock-in**: Verifies keys can be recreated on any Phala worker or Dstack node with the same app-id
+- **No Vendor Lock-in**: Verifies keys can be recreated on any Phala worker or dstack node with the same app-id
 
 **Why it matters**: Unlike traditional cloud platforms where encryption keys are tied to specific hardware or vendor infrastructure, Phala's decentralized key management ensures your keys are derived from your application identity, not the physical machine. This means you can migrate your application between different compute providers while maintaining access to your encrypted data. The KMS verification proves that your keys are generated securely and consistently, without giving Phala or any single party control over your encryption keys.
 
@@ -217,7 +217,7 @@ See [Trust Center Technical Documentation](/dstack/trust-center-technical) for A
 | **Public Auditability** | ✅ Shareable URL | ⚠️ Must share raw quote data |
 | **Verification Speed** | ✅ Seconds | ⚠️ Minutes to hours |
 | **Technical Expertise** | ✅ No expertise needed | ❌ Requires cryptography knowledge |
-| **Blockchain Integration** | ✅ Verifies on-chain records | ⚠️ Manual registry lookup |
+| **Blockchain Integration** | ✅ Verifies onchain records | ⚠️ Manual registry lookup |
 
 For most users, Trust Center provides the easiest and most reliable verification. Advanced users can still perform [manual verification](/phala-cloud/attestation/verifying-attestation) for full control.
 

--- a/phala-cloud/changelog.mdx
+++ b/phala-cloud/changelog.mdx
@@ -509,11 +509,11 @@ icon: "clock"
 
 </Update>
 
-<Update label="May 26 - June 1, 2025" tags={["KMS", "Security"]} rss={{ title: "On-Chain KMS Integration", description: "KMS integration for CVM launches and updates" }}>
+<Update label="May 26 - June 1, 2025" tags={["KMS", "Security"]} rss={{ title: "Onchain KMS Integration", description: "KMS integration for CVM launches and updates" }}>
 
   ## KMS Features
 
-  - **KMS on Launch**: On-chain KMS integration when launching CVMs
+  - **KMS on Launch**: Onchain KMS integration when launching CVMs
   - **KMS Compose Updates**: KMS integration for compose file updates
   - **KMS App Config**: New KMS app configuration drawer
   - **KMS List**: Returns KMS list in available nodes query
@@ -528,7 +528,7 @@ icon: "clock"
   ## Bug Fixes
 
   - Fixed salt synchronization issues
-  - Resolved tproxy settings in AppCompose migration
+  - Resolved dstack-gateway settings in AppCompose migration
   - Fixed OS image duplication checks
 
 </Update>

--- a/phala-cloud/faqs.mdx
+++ b/phala-cloud/faqs.mdx
@@ -135,7 +135,7 @@ article](https://phala.com/posts/how-to-generate-attestation-repport-and-prove-y
 
 ### What’s the best approach to verify Phala Cloud Attestation Report in a smart contract?
 
-You can verify the Attestation Report with [Automata's on-chain DCAP verifier](https://github.com/automata-network/automata-dcap-attestation) written in Solidity and deployed on multiple blockchains.
+You can verify the Attestation Report with [Automata's onchain DCAP verifier](https://github.com/automata-network/automata-dcap-attestation) written in Solidity and deployed on multiple blockchains.
 
 To verify the report, user can get the report hex data from Phala Cloud dashboard “Attestation” tab, and call the smart contract method verifyAndAttestOnChain, check the example [here](https://github.com/Leechael/ra-quote-explorer/blob/37a86a96f0f5059359b33fdb61b1f507fd1ca291/src/components/onchain_attestation.tsx#L152).
 

--- a/phala-cloud/getting-started/explore-templates/deploy-erc-8004-agent.mdx
+++ b/phala-cloud/getting-started/explore-templates/deploy-erc-8004-agent.mdx
@@ -5,10 +5,10 @@ description: "Deploy a verifiable ERC-8004 Trustless Agent using Phala Cloud's V
 
 ## TL;DR
 
-- **ERC-8004** gives us on-chain primitives to register and discover *trustless agents*.
+- **ERC-8004** gives us onchain primitives to register and discover *trustless agents*.
 - To make those registrations meaningful, you want verifiable runtime evidence, not just a signature.
 - **Confidential VMs (CVMs)** running **dstack** to deliver **deterministic key derivation** + **remote attestation** so your agent can prove *where* it executed.
-- **Phala Cloud** wraps this in a bow: VibeVM templates, an on-chain KMS/registry workflow, and (optionally) confidential inference (GPU TEE) support.
+- **Phala Cloud** wraps this in a bow: VibeVM templates, an onchain KMS/registry workflow, and (optionally) confidential inference (GPU TEE) support.
 - This post walks the whole flow: deploy a CVM → produce attestation → register identity on Sepolia → verify via **TEERegistry**.
 
 <iframe width="100%" height="400" src="https://www.youtube.com/embed/OP99InL0cU8" title="Deploy ERC-8004 Agent Overview" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
@@ -19,7 +19,7 @@ description: "Deploy a verifiable ERC-8004 Trustless Agent using Phala Cloud's V
 
 Distributed systems increasingly outsource work to off-chain agents—indexers, oracles, model inference, payment relays. When an agent signs a statement or moves value, a bare signature only proves **key possession**, not execution context. The missing link is provenance: *did this response come from the runtime I expect?*
 
-**ERC-8004** gives us a compact on-chain model for agent identity and discovery. Pair it with TEE-backed CVMs and you get the runtime receipts you've been wishing for: **attested execution**. Explore more [confidential AI agent use cases](https://phala.com/solutions/ai-agents) and implementations.
+**ERC-8004** gives us a compact onchain model for agent identity and discovery. Pair it with TEE-backed CVMs and you get the runtime receipts you've been wishing for: **attested execution**. Explore more [confidential AI agent use cases](https://phala.com/solutions/ai-agents) and implementations.
 
 ---
 
@@ -30,9 +30,9 @@ Distributed systems increasingly outsource work to off-chain agents—indexers, 
 - What agents actually need:
     1. **Deterministic key material** derived inside the runtime.
     2. **Remote attestation** that binds keys + code measurements to a platform identity.
-    3. **On-chain discovery** so other contracts/clients can programmatically verify them.
+    3. **Onchain discovery** so other contracts/clients can programmatically verify them.
 
-ERC-8004 covers the on-chain identity/registry. **TEEs + CVMs** supply runtime evidence. **Phala Cloud** ties it all together with templates, SDKs, and an on-chain governance/KMS model.
+ERC-8004 covers the onchain identity/registry. **TEEs + CVMs** supply runtime evidence. **Phala Cloud** ties it all together with templates, SDKs, and an onchain governance/KMS model.
 
 ---
 
@@ -135,7 +135,7 @@ https://<dstack-app-id>-8000.<dstack-gateway-domain>
 
 ### 9) Talk to the agent
 
-- Hit the Agent API. You should get signed responses whose key matches what you registered, and whose runtime is backed by the TEE attestation on-chain.
+- Hit the Agent API. You should get signed responses whose key matches what you registered, and whose runtime is backed by the TEE attestation onchain.
 
 <iframe width="100%" height="400" src="https://www.youtube.com/embed/f4Ii_sb7KMg" title="Interact with Agent" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
@@ -158,7 +158,7 @@ flowchart LR
 
 ## Conclusion
 
-ERC-8004 + TEE on **Phala Cloud** give you a practical path to trustless agents: deterministic keys, remote attestations, and on-chain identity—wrapped in a dev flow that feels like spinning up a regular VM, just with superpowers.
+ERC-8004 + TEE on **Phala Cloud** give you a practical path to trustless agents: deterministic keys, remote attestations, and onchain identity—wrapped in a dev flow that feels like spinning up a regular VM, just with superpowers.
 
 ## Resources
 

--- a/phala-cloud/getting-started/explore-templates/overview.mdx
+++ b/phala-cloud/getting-started/explore-templates/overview.mdx
@@ -4,7 +4,7 @@ title: Quick Start Guide
 ---
 
 <Frame caption="Phala Cloud Templates">
-  <img src="/images/getting-started/phala-cloud-template.png" alt="Phala Cloud Templates page with search bar and category filters including MCP, A2A, x402, Dstack, VRF, and template cards for Anyone Anon Service, Anyone Network Relay, and MOOF MCP" />
+  <img src="/images/getting-started/phala-cloud-template.png" alt="Phala Cloud Templates page with search bar and category filters including MCP, A2A, x402, dstack, VRF, and template cards for Anyone Anon Service, Anyone Network Relay, and MOOF MCP" />
 </Frame>
 
 This guide outlines a structured method for deploying confidential applications on Phala Cloud. Use [**Phala Cloud Templates**](https://cloud.phala.network/templates) to integrate pre-built, production-grade setups. These templates support rapid deployment with minimal custom code, covering frameworks like MCP, A2A, Next.js, x402, and others.

--- a/phala-cloud/getting-started/explore-templates/start-from-template.mdx
+++ b/phala-cloud/getting-started/explore-templates/start-from-template.mdx
@@ -41,7 +41,7 @@ yarn
 cp env.local.example .env.local
 ```
 
-We also need to download the DStack simulator:
+We also need to download the dstack simulator:
 
 ```shell
 # Mac
@@ -177,7 +177,7 @@ python -m pip install -r requirements.txt
 cp env.example .env
 ```
 
-We also need to download the DStack simulator:
+We also need to download the dstack simulator:
 
 ```bash
 # Mac
@@ -281,4 +281,4 @@ Output of **GET /sol_account**
 
 ## Conclusion
 
-The last 2 tutorials were key to understanding the basics of deploying a Docker app on a TEE Server. Now you are ready to start building on Dstack! For more info on the design of Dstack, check out the [Design Documents](/dstack/design-documents/whitepaper).
+The last 2 tutorials were key to understanding the basics of deploying a Docker app on a TEE Server. Now you are ready to start building on dstack! For more info on the design of dstack, check out the [Design Documents](/dstack/design-documents/whitepaper).

--- a/phala-cloud/key-management/key-management-protocol.mdx
+++ b/phala-cloud/key-management/key-management-protocol.mdx
@@ -33,18 +33,18 @@ DeRoT is designed to enhance the functionalities of the current hardware-kept se
 
 ## Unique Challenge: Stealthy Deployer Attack <a href="#p-8432-unique-challenge-stealthy-deployer-attack-3" id="p-8432-unique-challenge-stealthy-deployer-attack-3"></a>
 
-Unlike in smart contracts that every operation is observable on-chain, the introduce of DeRoT enables a blockchain-TEE hybrid system where the interactions can happen both on-chain and invisibly off-chain. Also, the support for upgradable application code will introduce more risks since the benign code may be changed to dump the encrypted data in an unconscious way.
+Unlike in smart contracts that every operation is observable onchain, the introduce of DeRoT enables a blockchain-TEE hybrid system where the interactions can happen both onchain and invisibly off-chain. Also, the support for upgradable application code will introduce more risks since the benign code may be changed to dump the encrypted data in an unconscious way.
 
 Considering the following attack from a malicious application deployer:
 
 1. An open-source benign application is deployed to TEE and trusted by its users to process the privacy data;
 2. The deployer asks the DeRoT to upgrade the application code. It seems no reason to reject it since he is the owner;
-3. The deployer injects malicious logic to dump all the privacy data in the new code, but doesn’t announce this to the public. Since this upgrade is between the TEE and DeRoT, it is not observable from the on-chain perspective;
+3. The deployer injects malicious logic to dump all the privacy data in the new code, but doesn't announce this to the public. Since this upgrade is between the TEE and DeRoT, it is not observable from the onchain perspective;
 4. The deployer can make another upgrade to remove the malicious logic to erase the evidence.
 
 Actually, similar attacks on the upgradable smart contracts happened before, but the difference is that such attack will not be naturally perceived when the application and the DeRoT are running off-chain. It’s worth noting that adding more access control on the application upgrade operation (e.g. enforce a multi-sig smart contract) cannot mitigate this risk.
 
-This attack motivates an important principle in our design: _every operation involving key authorization changes must be initiated on-chain to ensure observability_. This will ensure the security equivalence to existing smart contracts.
+This attack motivates an important principle in our design: _every operation involving key authorization changes must be initiated onchain to ensure observability_. This will ensure the security equivalence to existing smart contracts.
 
 ## Design <a href="#p-8432-design-4" id="p-8432-design-4"></a>
 
@@ -58,8 +58,8 @@ To enable the verification on the DeRoT program integrity and correctness, its m
 
 1. The DeRoT code is open-source for anyone to do code and security review to ensure the correctness of key management logic and no backdoors;
 2. The executable must be produced with reproducible build so the verifier can know it matches the source code;
-3. The digest of valid executable is published through on-chain governance;
-4. Multiple DeRoT instances run inside TEE. Here we only rely on TEE to provide the measurement over the executable, and ensure it matches the digest on chain.
+3. The digest of valid executable is published through onchain governance;
+4. Multiple DeRoT instances run inside TEE. Here we only rely on TEE to provide the measurement over the executable, and ensure it matches the digest onchain.
 
 Apart from RA report verification, the core logic of key management in DeRoT is quite compact. It just involves two operations:
 
@@ -68,7 +68,7 @@ Apart from RA report verification, the core logic of key management in DeRoT is 
 
 Because of the simple logic, it can use MPC/FHE-based threshold key generation and derivation with no concern about the performance overhead.
 
-The public key of RootKey must be published on-chain to enable any party to verify the validity of application keys with it. We will show that such root-key-derivation pattern is important to enable an efficient key rotation in the following section.
+The public key of RootKey must be published onchain to enable any party to verify the validity of application keys with it. We will show that such root-key-derivation pattern is important to enable an efficient key rotation in the following section.
 
 ### Key Derivation <a href="#p-8432-key-derivation-6" id="p-8432-key-derivation-6"></a>
 

--- a/phala-cloud/phala-cloud-cli/overview.mdx
+++ b/phala-cloud/phala-cloud-cli/overview.mdx
@@ -37,7 +37,7 @@ To deploy applications to Phala Cloud, you'll need an API key:
 ## Deploy Your First TEE App
 
 ```bash
-# Deploy the webshell Dstack example
+# Deploy the webshell dstack example
 phala cvms create
 ```
 

--- a/phala-cloud/phala-cloud-cli/start-from-cloud-cli.mdx
+++ b/phala-cloud/phala-cloud-cli/start-from-cloud-cli.mdx
@@ -176,7 +176,7 @@ Let’s try a couple function to test with the [dstack python SDK](https://githu
 * **Remote Attestation**
 * **Key Derive with Key Management Service**
 
-#### Install Dstack SDK
+#### Install dstack SDK
 
 <Frame>
     <img src="https://img0.phala.world/files/1c20317e-04a1-80a1-91e9-fe32a4f39af9.jpg" alt="Installing dstack SDK in Jupyter notebook with pip install command" />

--- a/phala-cloud/what-is/what-is-phala-cloud.mdx
+++ b/phala-cloud/what-is/what-is-phala-cloud.mdx
@@ -52,7 +52,7 @@ Understanding Phala Cloud's architecture:
     Secure cryptographic key generation and management
   </Card>
   
-  <Card title="Dstack SDK" icon="code" href="/dstack/getting-started">
+  <Card title="dstack SDK" icon="code" href="/dstack/getting-started">
     Developer tools for building on Phala Cloud
   </Card>
 </CardGroup>


### PR DESCRIPTION
Fixes terminology inconsistencies across documentation.

- dstack (not Dstack/DStack/dStack)
- dstack-gateway (not tproxy)  
- onchain (not on-chain)