### PR TITLE
docs: update SSH documentation with phala ssh command

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -374,7 +374,8 @@
                       "/phala-cloud/references/phala-cloud-cli/phala/auth",
                       "/phala-cloud/references/phala-cloud-cli/phala/cvms",
                       "/phala-cloud/references/phala-cloud-cli/phala/docker",
-                      "/phala-cloud/references/phala-cloud-cli/phala/simulator"
+                      "/phala-cloud/references/phala-cloud-cli/phala/simulator",
+                      "/phala-cloud/references/phala-cloud-cli/phala/ssh"
                     ]
                   },
                   "/phala-cloud/references/migration-from-dstack-v03"

--- a/phala-cloud/getting-started/start-from-cloud-ui.mdx
+++ b/phala-cloud/getting-started/start-from-cloud-ui.mdx
@@ -42,7 +42,7 @@ Click the **Deploy** -> **docker-compose.yml** in the top-right corner of the cl
         command: "start-notebook.sh --NotebookApp.token=${TOKEN}"
     ```
 
-3.  Choose the **Computing Resources** plan. There are some preset plans available, or you can customize them for more flexibility. In **Node & Image** section, we recommend choosing **dstack-dev-** as guest image if you are deploying for testing. It will enable the debug feature that you can login to the virtual machine in the future.
+3.  Choose the **Computing Resources** plan. There are some preset plans available, or you can customize them for more flexibility. In **Node & Image** section, we recommend choosing **dstack-dev-** as guest image if you are deploying for testing. This enables [SSH access](/phala-cloud/networking/enable-ssh-access) for debugging.
 
 
     <Frame caption="Compute Resources">

--- a/phala-cloud/networking/enable-ssh-access.mdx
+++ b/phala-cloud/networking/enable-ssh-access.mdx
@@ -1,35 +1,67 @@
 ---
-title: Enable SSH Access  
+title: Enable SSH Access
 description: Connect to your CVM via SSH for debugging and management
 ---
 
 <Warning>
-SSH access is only available when you deploy with a **dev** OS image. Select "dstack-dev" as the OS type when creating your CVM. Production OS images have SSH disabled for security.
+SSH access is only available with **dev** OS images. Select "dstack-dev" when creating your CVM. Production images have SSH disabled for security.
 </Warning>
 
-This guide shows you how to SSH into your CVM through the secure gateway tunnel.
+The easiest way to SSH into your CVM is with the Phala CLI. One command connects you through the secure gateway tunnel.
 
 ## Prerequisites
 
-- SSH client on your local machine
-- OpenSSL installed
+- [Phala CLI](/phala-cloud/phala-cloud-cli/overview) (latest version)
 - CVM deployed with Development OS
 
-## Step 1: Set Root Credentials
+## Step 1: Configure SSH Keys
 
-When deploying your CVM, set one of these environment variables:
+Start by adding your SSH keys in **Account Settings > SSH Keys** on the [Phala Cloud dashboard](https://cloud.phala.com/account/settings). You can add keys manually or sync them from GitHub. All saved keys are automatically added to every new CVM you deploy.
 
-**For password authentication:**
-- Add `DSTACK_ROOT_PASSWORD` as a secure environment variable
+When creating a CVM, the SSH Authorization section lets you add an additional root password or public key specific to that instance. These are added alongside your account keys.
 
-**For key-based authentication (recommended):**
-- Add `DSTACK_ROOT_PUBLIC_KEY` with your SSH public key
+<Note>
+SSH keys are injected **only at CVM creation time**. Updating your account keys won't affect already-deployed CVMs. To modify credentials on existing CVMs, use **Code Update** to set the `DSTACK_ROOT_PASSWORD` or `DSTACK_ROOT_PUBLIC_KEY` environment variables.
+</Note>
 
-If you need to add credentials after deployment, use "Code Update" in the dashboard to modify environment variables.
+## Step 2: Connect
 
-## Step 2: Configure Your SSH Client
+```bash
+# Connect using phala.toml configuration
+phala ssh
 
-Add this to your `~/.ssh/config` file:
+# Or specify the CVM name directly
+phala ssh my-cvm
+```
+
+That's it. The CLI handles the gateway tunnel and SSH configuration automatically.
+
+## Useful Options
+
+The `phala ssh` command supports several options:
+
+```bash
+# Preview the SSH command without connecting
+phala ssh my-cvm --dry-run
+
+# Enable verbose output for debugging
+phala ssh my-cvm -v
+
+# Forward a local port to the CVM
+phala ssh my-cvm -- -L 8080:localhost:80
+```
+
+See the [CLI reference](/phala-cloud/references/phala-cloud-cli/phala/ssh) for all options.
+
+<Accordion title="Manual SSH Configuration">
+
+If you prefer manual configuration or need to customize your setup, use `phala ssh --dry-run` to generate the SSH config:
+
+```bash
+phala ssh my-cvm --dry-run
+```
+
+This outputs a working SSH command you can adapt. The underlying mechanism uses OpenSSL to tunnel SSH through TLS:
 
 ```bash
 Host my-cvm
@@ -39,21 +71,13 @@ Host my-cvm
     ProxyCommand openssl s_client -quiet -connect %h:%p
 ```
 
-Replace:
-- `<app-id>` with your application ID (find it in the dashboard)
-- `<cluster>` with your cluster (e.g., `us`)
+Replace `<app-id>` with your application ID and `<cluster>` with your cluster (e.g., `dstack-pha-prod7`).
 
-## Step 3: Connect
+**macOS users:** If you encounter connection timeouts, you may have LibreSSL instead of OpenSSL. Install OpenSSL via Homebrew and use the full path: `/opt/homebrew/bin/openssl`.
 
-```bash
-ssh my-cvm
-```
+**Windows users:** Install OpenSSL via [Chocolatey](https://chocolatey.org/) (`choco install openssl`) and use the full path in ProxyCommand. Alternatively, use WSL where the Linux instructions work directly.
 
-That's it. You're now connected to your CVM through the secure gateway tunnel.
-
-<Note>
-**macOS users:** If you encounter connection timeouts, you may have LibreSSL instead of OpenSSL. Install OpenSSL via Homebrew (`brew install openssl`) and update your ProxyCommand to use the full path to the Homebrew OpenSSL binary.
-</Note>
+</Accordion>
 
 ## What You Can Do
 
@@ -71,82 +95,18 @@ docker stats
 # Debug networking
 curl http://localhost:8080
 netstat -tulpn
-wg show
 ```
 
-## Security Notes
-
-- SSH traffic is tunneled through TLS via the gateway
-- Only your code inside the TEE can see the decrypted SSH session
-- Use key-based authentication for production debugging
-- Remember to switch to Production OS when you're done debugging
-
-## Windows SSH Access
-
-Windows users can connect to CVMs using PowerShell or Windows Terminal with OpenSSL.
-
-### Option 1: Using Windows OpenSSL
-
-1. **Install OpenSSL for Windows:**
-   - Download from [slproweb.com/products/Win32OpenSSL.html](https://slproweb.com/products/Win32OpenSSL.html)
-   - Or install via Chocolatey: `choco install openssl`
-
-2. **Create SSH config file:**
-
-   Create or edit `C:\Users\<YourUsername>\.ssh\config`:
-   ```
-   Host my-cvm
-       HostName <app-id>-22.<cluster>.phala.network
-       User root
-       Port 443
-       ProxyCommand "C:\Program Files\OpenSSL-Win64\bin\openssl.exe" s_client -quiet -connect %h:%p
-   ```
-
-3. **Connect:**
-   ```powershell
-   ssh my-cvm
-   ```
-
-### Option 2: Using WSL (Windows Subsystem for Linux)
-
-If you have WSL installed, the Linux instructions work directly:
-
-1. Open WSL terminal
-2. Edit `~/.ssh/config` as shown in the main guide
-3. Connect with `ssh my-cvm`
-
-### Option 3: Using PuTTY with Plink
-
-1. Install [PuTTY](https://www.putty.org/)
-2. Use Plink with OpenSSL tunneling:
-   ```powershell
-   plink -proxycmd "openssl s_client -quiet -connect <app-id>-22.<cluster>.phala.network:443" root@<app-id>-22.<cluster>.phala.network
-   ```
-
-<Note>
-**Windows OpenSSL Path:** If you installed OpenSSL to a different location, update the path in the ProxyCommand accordingly.
-</Note>
+<Tip>
+Remember to switch to a Production OS image when you're done debugging.
+</Tip>
 
 ## Troubleshooting
 
-**Permission denied?**
-- Verify your credentials are set in environment variables
-- Use "Code Update" to add them if forgotten during deployment
+| Issue | Solution |
+|-------|----------|
+| Permission denied | Check Account Settings for saved keys. For existing CVMs, use Code Update to set credentials. |
+| Connection refused | Confirm you deployed with Development OS, not Production |
+| Connection timeout | Run `phala ssh -v` to see detailed connection info |
 
-**Connection timeout?**
-- Check your OpenSSL version: `openssl version`
-- macOS users: ensure you're using OpenSSL, not LibreSSL
-- Windows users: verify OpenSSL is in your PATH or use the full path
-
-**Connection refused?**
-- Confirm you deployed with Development OS, not Production OS
-
-**Windows: 'openssl' is not recognized**
-- Install OpenSSL and add it to your system PATH
-- Or use the full path to openssl.exe in the ProxyCommand
-
-## Next Steps
-
-- [Monitor logs](/phala-cloud/monitoring/public-logs)
-- [Set up custom domains](/phala-cloud/networking/setup-custom-domain)
-- [Learn about security](/phala-cloud/networking/security)
+For more detailed troubleshooting, see [Networking Troubleshooting](/phala-cloud/networking/troubleshooting#ssh-access-denied).

--- a/phala-cloud/networking/troubleshooting.mdx
+++ b/phala-cloud/networking/troubleshooting.mdx
@@ -211,31 +211,33 @@ grpcurl -plaintext localhost:50051 list
 
 SSH only works with development OS images. Production images have SSH disabled.
 
-### Check Configuration
+### Debug with Verbose Mode
+
+Use the Phala CLI with verbose output to diagnose connection issues:
 
 ```bash
-# Verify environment variables are set
-DSTACK_ROOT_PASSWORD=yourpassword
-# OR
-DSTACK_ROOT_PUBLIC_KEY=ssh-rsa AAAA...
-
-# Test connection
-ssh -v my-cvm
-
-# Test ProxyCommand directly
-openssl s_client -connect <app-id>-22.dstack-prod5.phala.network:443
+phala ssh my-cvm -v
 ```
+
+This shows detailed connection information including gateway resolution and SSH handshake.
+
+### Check SSH Keys
+
+SSH keys from Account Settings are only injected at CVM creation time. If you added keys after deployment, use Code Update to set `DSTACK_ROOT_PUBLIC_KEY`.
 
 ### macOS OpenSSL Issue
 
-macOS uses LibreSSL which may cause issues:
+If using manual SSH configuration, macOS LibreSSL may cause timeouts:
+
 ```bash
 # Install OpenSSL via Homebrew
 brew install openssl
 
-# Update SSH config
-ProxyCommand /opt/homebrew/bin/openssl s_client -quiet -connect %h:%p
+# Use full path in ProxyCommand
+/opt/homebrew/bin/openssl s_client -quiet -connect %h:%p
 ```
+
+For detailed SSH setup, see [Enable SSH Access](/phala-cloud/networking/enable-ssh-access).
 
 ## Debugging Commands
 

--- a/phala-cloud/references/phala-cloud-cli/phala/ssh.mdx
+++ b/phala-cloud/references/phala-cloud-cli/phala/ssh.mdx
@@ -1,0 +1,126 @@
+---
+description: Connect to a CVM via SSH through the secure gateway tunnel.
+title: ssh
+---
+
+## Command: `ssh`
+
+#### Syntax
+
+```
+phala ssh [options] [<cvm-name>] [--] [...]
+```
+
+### Description
+
+The `phala ssh` command connects you to a CVM via SSH through the secure gateway tunnel. It handles all the gateway configuration automatically.
+
+```bash
+Usage: phala ssh [options] [<cvm-name>] [--] [...]
+
+Connect to a CVM via SSH
+
+Arguments:
+  <cvm-name>?       CVM name. If not provided, reads from phala.toml
+
+Options:
+  -h, --help              Show help information
+  -p, --port <value>      Gateway port (default: 443)
+  -g, --gateway <value>   Gateway domain (skips API call for offline usage)
+  -t, --timeout <value>   Connection timeout in seconds (default: 30)
+  -v, --verbose           Show verbose connection details
+  --dry-run               Print the SSH command without executing it
+
+Pass-through (after --):
+  All arguments after -- are passed directly to ssh.
+```
+
+### Examples
+
+* Connect using phala.toml configuration
+
+```bash
+phala ssh
+```
+
+* Connect to a specific CVM
+
+```bash
+phala ssh my-app
+```
+
+* Preview the SSH command without connecting
+
+```bash
+phala ssh my-app --dry-run
+```
+
+<details>
+
+<summary>Example Output</summary>
+
+```bash
+ssh -o ProxyCommand="openssl s_client -quiet -connect %h:%p" \
+    -o StrictHostKeyChecking=no \
+    root@abc123def456-22.dstack-prod5.phala.network -p 443
+```
+
+</details>
+
+* Connect with verbose output for debugging
+
+```bash
+phala ssh my-app -v
+```
+
+* Forward a local port to the CVM
+
+```bash
+phala ssh my-app -- -L 8080:localhost:80
+```
+
+This forwards your local port 8080 to port 80 on the CVM.
+
+* Set up a SOCKS proxy
+
+```bash
+phala ssh my-app -- -D 1080 -N
+```
+
+This creates a SOCKS proxy on local port 1080 without executing a remote command.
+
+* Execute a remote command
+
+```bash
+phala ssh my-app -- docker ps -a
+```
+
+* Connect with a custom SSH key
+
+```bash
+phala ssh my-app -- -i ~/.ssh/custom_key
+```
+
+* Offline mode (skip API lookup)
+
+```bash
+phala ssh my-app -g dstack-prod5.phala.network -p 443
+```
+
+When you specify the gateway domain, the CLI skips the API call and connects directly.
+
+### Pass-through Options
+
+Any arguments after `--` are passed directly to the underlying SSH command. Common options include:
+
+| Option | Description |
+|--------|-------------|
+| `-i <keyfile>` | Use a specific identity file |
+| `-L <local>:<remote>` | Local port forwarding |
+| `-R <remote>:<local>` | Remote port forwarding |
+| `-D <port>` | Dynamic SOCKS proxy |
+| `-v` | SSH verbose mode |
+
+<Note>
+The `-o ProxyCommand` option is blocked since the CLI manages the proxy configuration automatically.
+</Note>

--- a/phala-cloud/troubleshooting/debug-your-application.mdx
+++ b/phala-cloud/troubleshooting/debug-your-application.mdx
@@ -1,63 +1,31 @@
 ---
-description: Create and manage Confidential Virtual Machines (CVMs) on Phala Cloud.
+description: Access your CVM for debugging and troubleshooting.
 title: Debug Application
 ---
 
+When deploying on Phala Cloud, you choose between two CVM base images:
 
-When deploying your application on the Phala Cloud UI, you can choose between two types of CVM base images: `dstack-<version>` and `dstack-dev-<version>`. The dev image allows you to log in to the CVM in the future for debugging purposes. If you opt for a non-dev image, rest assured that no one will have the ability to access your CVM, either physically or remotely.
+- **`dstack-<version>`** (Production): No remote access. Use this for production deployments.
+- **`dstack-dev-<version>`** (Development): Allows SSH access for debugging.
 
 <Note type="danger">
-The `dstack-dev-<version>` images are not recommended for production environments.
+Development images are not recommended for production environments.
 </Note>
 
-<Frame caption="debug-cvm">
-    <img src="/images/cloud-config-compute-resource.png" alt="debug-cvm" />
+## SSH Access
 
-</Frame>
+The easiest way to debug your CVM is via SSH using the Phala CLI:
 
-For example, to enable the use of tool **ttypd** for logging into your CVM from a web browser, you need to add a ttypd service to your Docker Compose file as shown below:
-
-```yaml
-services:
-  alpine-ttypd:
-    image: hackinglab/alpine-ttyd-bash:3.2
-    environment:
-    - AUTHOR=e1
-    - HL_USER_USERNAME=root
-    - HL_USER_PASSWORD=123QWEasd
-    ports:
-      - 7681:7681
-    volumes:
-      - /:/host
-    network_mode: host
+```bash
+phala ssh my-cvm
 ```
 
-<Frame caption="config-ttyd-service">
-    <img src="/images/cloud-config-ttyd-service.png" alt="config-ttyd-service" />
+Once connected, you can inspect containers, check logs, and debug networking:
 
-</Frame>
+```bash
+docker ps -a
+docker logs <container-name>
+htop
+```
 
-You can then view a specific endpoint for the ttypd service by navigating to "**View Details**" → "**Network**." and if you check the **Container** tab, you will see there is a container running for the ttypd service.
-
-<Frame caption="view-ttyd-container">
-    <img src="/images/cloud-view-ttyd-container.png" alt="view-ttyd-container" />
-
-</Frame>
-
-When you open this endpoint in your browser (in this case, `https://7c7629f605a50abe5797e1b6bab115fec6b9e7ac-7681.dstack-prod5.phala.network/`), you will see a terminal interface. The next step is to install the **openssh-client**.
-
-<Note type="info">
-The base image is not Debian-based, so you will not be able to use the `apt` package manager. Instead, you will use the `apk` package manager.
-</Note>
-
-<Frame caption="ttyd-terminal">
-    <img src="/images/cloud-ttyd-terminal.png" alt="ttyd-terminal" />
-
-</Frame>
-
-You can now log in to the CVM using the command `ssh root@localhost`. As shown below, you can retrieve information about running Docker containers by executing the command `docker ps -a` within the CVM.
-
-<Frame caption="cvm-login">
-    <img src="/images/cloud-cvm-login.png" alt="cvm-login" />
-
-</Frame>
+For setup instructions, see [Enable SSH Access](/phala-cloud/networking/enable-ssh-access).


### PR DESCRIPTION
## Summary
- Rewrite SSH docs with `phala ssh` as primary method
- Add CLI reference page for `phala ssh` command
- Clarify SSH key injection timing (only at CVM creation)
- Simplify debug page, remove ttyd workaround

## Test plan
- [x] Verify all internal links work
- [x] Test `phala ssh` examples are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)