### PR TITLE
feat: add CLI documentation generator script

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -371,11 +371,18 @@
                     "group": "CLI Reference",
                     "pages": [
                       "/phala-cloud/references/phala-cloud-cli/phala/overview",
-                      "/phala-cloud/references/phala-cloud-cli/phala/auth",
+                      "/phala-cloud/references/phala-cloud-cli/phala/login",
+                      "/phala-cloud/references/phala-cloud-cli/phala/logout",
+                      "/phala-cloud/references/phala-cloud-cli/phala/status",
+                      "/phala-cloud/references/phala-cloud-cli/phala/deploy",
                       "/phala-cloud/references/phala-cloud-cli/phala/cvms",
+                      "/phala-cloud/references/phala-cloud-cli/phala/ssh",
+                      "/phala-cloud/references/phala-cloud-cli/phala/cp",
                       "/phala-cloud/references/phala-cloud-cli/phala/docker",
                       "/phala-cloud/references/phala-cloud-cli/phala/simulator",
-                      "/phala-cloud/references/phala-cloud-cli/phala/ssh"
+                      "/phala-cloud/references/phala-cloud-cli/phala/nodes",
+                      "/phala-cloud/references/phala-cloud-cli/phala/config",
+                      "/phala-cloud/references/phala-cloud-cli/phala/auth"
                     ]
                   },
                   "/phala-cloud/references/migration-from-dstack-v03"

--- a/phala-cloud/references/phala-cloud-cli/phala/auth.mdx
+++ b/phala-cloud/references/phala-cloud-cli/phala/auth.mdx
@@ -1,89 +1,43 @@
 ---
-description: Deploy confidential applications with Phala Cloud's managed TEE infrastructure.
-title: auth
+title: "auth (Deprecated)"
+description: "Authenticate with Phala Cloud"
 ---
 
+<Warning>
+This command is deprecated. Use `phala login`, `phala logout`, and `phala status` instead.
+</Warning>
 
-## Command: `auth`
+## Command: `phala auth`
 
-#### Syntax
+### Syntax
 
 ```
-phala auth [options] [command]
+phala auth <command> [options]
 ```
 
 ### Description
 
-The `phala auth`  command is used to authenticate a user's API key to manage their Phala Cloud account.
-
-```bash
-Usage: phala auth [options] [command]
-
 Authenticate with Phala Cloud
 
-Options:
-  -h, --help        display help for command
+### Options
 
-Commands:
-  login [api-key]   Set the API key for authentication
-  logout            Remove the stored API key
-  status [options]  Check authentication status
-  help [command]    display help for command
-```
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+
+### Deprecated Subcommands
+
+| Command | Description |
+| ------- | ----------- |
+| `login` | Authenticate with Phala Cloud (use 'phala login' instead) |
+| `logout` | Remove the stored API key (use 'phala logout' instead) |
+| `status` | Check authentication status (use 'phala status' instead) |
 
 ### Examples
 
-* Display help
+* Display help:
 
 ```bash
 phala auth --help
-```
-
-* Login to Phala Cloud with API Key
-
-```bash
-phala auth login <your-api-key>
-```
-
-* Login to Phala Cloud with user prompt
-
-```bash
-phala auth login
-? Enter your API key: › *********************
-```
-
-* Get Status of Login
-
-```bash
-phala auth status
-```
-
-<details>
-
-<summary>Example Output</summary>
-
-```bash
-⟳ Checking authentication status... ✓
-
-✓ Authenticated as bitsbender
-╭────────────┬─────────────────────────────────╮
-├────────────┼─────────────────────────────────┤
-│ Username   │ bitsbender                      │
-├────────────┼─────────────────────────────────┤
-│ Email      │ hashwarlock@protonmail.com      │
-├────────────┼─────────────────────────────────┤
-│ Role       │ user                            │
-├────────────┼─────────────────────────────────┤
-│ Team       │ bitsbender's projects (free)    │
-├────────────┼─────────────────────────────────┤
-│ Credits    │ $20                            │
-╰────────────┴─────────────────────────────────╯
-```
-
-</details>
-
-* Logout of Phala Cloud
-
-```bash
-phala auth logout
 ```

--- a/phala-cloud/references/phala-cloud-cli/phala/config.mdx
+++ b/phala-cloud/references/phala-cloud-cli/phala/config.mdx
@@ -1,23 +1,19 @@
 ---
-title: "simulator"
-description: "TEE simulator commands"
+title: "config"
+description: "Manage your local configuration"
 ---
 
-<Note>
-This command is marked as unstable and may change in future releases.
-</Note>
-
-## Command: `phala simulator`
+## Command: `phala config`
 
 ### Syntax
 
 ```
-phala simulator <command> [options]
+phala config <command> [options]
 ```
 
 ### Description
 
-TEE simulator commands
+Manage your local configuration
 
 ### Options
 
@@ -30,13 +26,14 @@ TEE simulator commands
 
 | Command | Description |
 | ------- | ----------- |
-| `start` | Start the TEE simulator |
-| `stop` | Stop the TEE simulator |
+| `get` | Get a configuration value |
+| `list` | List all configuration values |
+| `set` | Set a configuration value |
 
 ### Examples
 
 * Display help:
 
 ```bash
-phala simulator --help
+phala config --help
 ```

--- a/phala-cloud/references/phala-cloud-cli/phala/cp.mdx
+++ b/phala-cloud/references/phala-cloud-cli/phala/cp.mdx
@@ -1,0 +1,85 @@
+---
+title: "cp"
+description: "Copy files to/from a CVM via SCP"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala cp`
+
+### Syntax
+
+```
+phala cp [options] <source> <destination>
+```
+
+### Description
+
+Copy files to/from a CVM via SCP
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<source>` | Source path. Local file or remote in format 'cvm-name:path'. Use ':path' to read cvm_id from phala.toml |
+| `<destination>` | Destination path. Local file or remote in format 'cvm-name:path'. Use ':path' to read cvm_id from phala.toml |
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `-i, --identity <value>` | SSH identity file (private key) |
+| `-p, --port <value>` | SSH port. Priority: CLI option > phala.toml gateway_port > 443 |
+| `-g, --gateway <value>` | Gateway domain. Priority: CLI option > phala.toml gateway_domain > API. When specified, skips API call for offline usage |
+| `-r, --recursive` | Recursively copy directories |
+| `-v, --verbose` | Show verbose SCP details |
+| `--dry-run` | Print the SCP command without executing it |
+
+### Examples
+
+* Upload using phala.toml cvm_id
+
+```bash
+phala cp ./local.txt :/root/remote.txt
+```
+
+* Upload to a specific CVM (queries API for gateway)
+
+```bash
+phala cp ./local.txt app_123:/root/remote.txt
+```
+
+* Download from CVM
+
+```bash
+phala cp app_123:/root/remote.txt ./local.txt
+```
+
+* Offline mode: copy without API (using phala.toml gateway)
+
+```bash
+phala cp -g dstack-prod5.phala.network -p 16185 ./file.txt app_123:/root/
+```
+
+* Upload directory recursively
+
+```bash
+phala cp -r ./local_dir app_123:/root/remote_dir
+```
+
+* Copy with custom SSH key
+
+```bash
+phala cp -i ~/.ssh/custom_key app_123:/root/file.txt ./file.txt
+```
+
+* Print the SCP command without executing
+
+```bash
+phala cp ./local.txt app_123:/root/remote.txt --dry-run
+```
+

--- a/phala-cloud/references/phala-cloud-cli/phala/cvms.mdx
+++ b/phala-cloud/references/phala-cloud-cli/phala/cvms.mdx
@@ -1,399 +1,59 @@
 ---
-description: Create and manage Confidential Virtual Machines (CVMs) on Phala Cloud.
-title: cvms
+title: "cvms"
+description: "Manage Phala Confidential Virtual Machines (CVMs)"
 ---
 
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
 
-## Command: cvms
+## Command: `phala cvms`
 
-#### Syntax
+### Syntax
 
 ```
-phala cvms [options] [command]
+phala cvms <command> [options]
 ```
 
 ### Description
 
-The `phala cvms`  command is used to manage the CVMs deployed to a user's account in Phala Cloud. These include fetching information about the deployments, deploying new CVMs, and managing the CVMs from the command line.
-
-```bash
-Usage: phala cvms [options] [command]
-
 Manage Phala Confidential Virtual Machines (CVMs)
 
-Options:
-  -h, --help                      display help for command
+### Options
 
-Commands:
-  attestation [options] [app-id]  Get attestation information for a CVM
-  create [options]                Create a new CVM
-  delete [options] [app-id]       Delete a CVM
-  get [options] [app-id]          Get details of a CVM
-  list|ls [options]               List all CVMs
-  start [app-id]                  Start a stopped CVM
-  stop [app-id]                   Stop a running CVM
-  resize [options] [app-id]       Resize resources for a CVM
-  restart [app-id]                Restart a CVM
-  upgrade [options] [app-id]      Upgrade a CVM to a new version
-  help [command]                  display help for command
-```
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+
+### Subcommands
+
+| Command | Description |
+| ------- | ----------- |
+| `attestation` | Get attestation information for a CVM |
+| `delete` | Delete a CVM |
+| `get` | Get details of a CVM |
+| `list` | List all CVMs |
+| `list-nodes` | List all available worker nodes. |
+| `logs` | Fetch container logs from a CVM |
+| `replicate` | Create a replica of an existing CVM |
+| `resize` | Resize resources for a CVM |
+| `restart` | Restart a CVM |
+| `serial-logs` | Fetch VM serial console logs from a CVM |
+| `start` | Start a stopped CVM |
+| `stop` | Stop a running CVM |
+
+### Deprecated Subcommands
+
+| Command | Description |
+| ------- | ----------- |
+| `create` | Create a new CVM (use "phala deploy" instead) |
+| `upgrade` | Upgrade a CVM to a new version (use "phala deploy" instead) |
 
 ### Examples
 
-* Display help
+* Display help:
 
 ```bash
 phala cvms --help
 ```
-
-* Create a new CVM
-
-```bash
-# without env file
-phala cvms create
-# with env file
-phala cvms create -e <path-to-env-file>
-```
-
-<details>
-
-<summary>Example Output</summary>
-
-```bash
-✔ Enter a name for the CVM: suh
-✔ Enter the path to your Docker Compose file: examples/timelock-nts/docker-compose.yml
-✓ Deleted DSTACK_SIMULATOR_ENDPOINT from current process
-✔ Do you want to skip environment variable prompt? Yes
-ℹ Skipping environment variable prompt
-✔ Enter number of vCPUs (default: 2): 2
-✔ Enter memory in MB (default: 4096): 4096
-✔ Enter disk size in GB (default: 40): 40
-⟳ Getting public key from CVM... ✓
-⟳ Encrypting environment variables... ✓
-⟳ Creating CVM... ✓
-✓ CVM created successfully
-ℹ CVM ID: 2936
-ℹ Name: suh
-ℹ Status: creating
-ℹ App ID: 00c6b8e73822fc86f64f2335d6812081d5ba2beb
-ℹ App URL: https://cloud.phala.com/dashboard/cvms/app_00c6b8e73822fc86f64f2335d6812081d5ba2beb
-ℹ 
-ℹ Your CVM is being created. You can check its status with:
-ℹ phala cvms get app_00c6b8e73822fc86f64f2335d6812081d5ba2beb
-```
-
-</details>
-
-* Get a CVM's Information
-
-```bash
-phala cvms get app_00c6b8e73822fc86f64f2335d6812081d5ba2beb
-```
-
-<details>
-
-<summary>Example Output</summary>
-
-```bash
-⟳ Fetching available CVMs... ✓
-✔ Select a CVM: suh (00c6b8e73822fc86f64f2335d6812081d5ba2beb) - Status: running
-⟳ Fetching CVM with App ID app_00c6b8e73822fc86f64f2335d6812081d5ba2beb... ✓
-
-╭──────────────┬────────────────────────────────────────────────────────────────────────────────────────────╮
-├──────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
-│ Name         │ suh                                                                                        │
-├──────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
-│ App ID       │ app_00c6b8e73822fc86f64f2335d6812081d5ba2beb                                               │
-├──────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
-│ Status       │ running                                                                                    │
-├──────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
-│ VCPU         │ 1                                                                                          │
-├──────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
-│ Memory       │ 1024 MB                                                                                    │
-├──────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
-│ Disk Size    │ 10 GB                                                                                      │
-├──────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
-│ Dstack Image │ dstack-0.3.5                                                                               │
-├──────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
-│ App URL      │ https://cloud.phala.com/dashboard/cvms/app_00c6b8e73822fc86f64f2335d6812081d5ba2beb    │
-╰──────────────┴────────────────────────────────────────────────────────────────────────────────────────────╯
-```
-
-</details>
-
-* List all CVMs
-
-```bash
-phala cvms ls
-```
-
-<details>
-
-<summary>Example Output</summary>
-
-```bash
-⟳ Fetching CVMs... ✓
-╭───────────────┬────────────────────────────────────────────────────────────────────────────────────────────╮
-├───────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
-│ Name          │ suh                                                                                        │
-├───────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
-│ App ID        │ app_00c6b8e73822fc86f64f2335d6812081d5ba2beb                                               │
-├───────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
-│ Status        │ running                                                                                    │
-├───────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
-│ Node Info URL │ https://36a6d736e7ebe09b090a345239ed527b372f1a87-8090.dstack-prod5.phala.network:443       │
-├───────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
-│ App URL       │ https://cloud.phala.com/dashboard/cvms/app_00c6b8e73822fc86f64f2335d6812081d5ba2beb    │
-╰───────────────┴────────────────────────────────────────────────────────────────────────────────────────────╯
-
-✓ Found 1 CVMs
-
-ℹ Go to https://cloud.phala.com/dashboard/ to view your CVMs
-```
-
-</details>
-
-* Fetch. an Attestation of a CVM
-
-```bash
-phala cvms attestation app_00c6b8e73822fc86f64f2335d6812081d5ba2beb
-```
-
-<details>
-
-<summary>Example Output</summary>
-
-```bash
-✓ CVM with App ID app_5592440286f5947743f58975a8335459d6fee5cd detected
-⟳ Fetching attestation information for CVM app_5592440286f5947743f58975a8335459d6fee5cd...... ✓
-✓ Attestation Summary:
-╭───────────────┬───────────────╮
-├───────────────┼───────────────┤
-│ Status        │ Online        │
-├───────────────┼───────────────┤
-│ Public Access │ Enabled       │
-├───────────────┼───────────────┤
-│ Error         │ None          │
-├───────────────┼───────────────┤
-│ Certificates  │ 2 found       │
-╰───────────────┴───────────────╯
-
-✓ Certificate #1 (End Entity):
-╭─────────────────────┬─────────────────────────────────────────────────────────────────────╮
-├─────────────────────┼─────────────────────────────────────────────────────────────────────┤
-│ Subject             │ 5592440286f5947743f58975a8335459d6fee5cd.phala                      │
-├─────────────────────┼─────────────────────────────────────────────────────────────────────┤
-│ Issuer              │ Phala KMS CA (Phala Network)                                        │
-├─────────────────────┼─────────────────────────────────────────────────────────────────────┤
-│ Serial Number       │ 1d651ceb77d826a547444fa140fd5ef2aa57a76e                            │
-├─────────────────────┼─────────────────────────────────────────────────────────────────────┤
-│ Validity            │ 12/31/1974, 6:00:00 PM to 3/14/2026, 2:03:35 PM                     │
-├─────────────────────┼─────────────────────────────────────────────────────────────────────┤
-│ Fingerprint         │ 0a69a723d5bd53a429626009ed99ed2e369062591ccba4ed62a4df5ff95122f8    │
-├─────────────────────┼─────────────────────────────────────────────────────────────────────┤
-│ Signature Algorithm │ ecdsa-with-SHA256                                                   │
-├─────────────────────┼─────────────────────────────────────────────────────────────────────┤
-│ Is CA               │ Yes                                                                 │
-├─────────────────────┼─────────────────────────────────────────────────────────────────────┤
-│ Position in Chain   │ 0                                                                   │
-╰─────────────────────┴─────────────────────────────────────────────────────────────────────╯
-
-✓ Certificate #2 (CA):
-╭─────────────────────┬─────────────────────────────────────────────────────────────────────╮
-├─────────────────────┼─────────────────────────────────────────────────────────────────────┤
-│ Subject             │ Phala KMS CA (Phala Network)                                        │
-├─────────────────────┼─────────────────────────────────────────────────────────────────────┤
-│ Issuer              │ Phala KMS CA (Phala Network)                                        │
-├─────────────────────┼─────────────────────────────────────────────────────────────────────┤
-│ Serial Number       │ 43a1a79f8766c24aa2274de642b481f9ada4438                             │
-├─────────────────────┼─────────────────────────────────────────────────────────────────────┤
-│ Validity            │ 12/31/1974, 6:00:00 PM to 12/31/4095, 6:00:00 PM                    │
-├─────────────────────┼─────────────────────────────────────────────────────────────────────┤
-│ Fingerprint         │ 68246c57488458f40e589c09ee348c0b823c3cb36599fff93d18a9a9699d1179    │
-├─────────────────────┼─────────────────────────────────────────────────────────────────────┤
-│ Signature Algorithm │ ecdsa-with-SHA256                                                   │
-├─────────────────────┼─────────────────────────────────────────────────────────────────────┤
-│ Is CA               │ Yes                                                                 │
-├─────────────────────┼─────────────────────────────────────────────────────────────────────┤
-│ Position in Chain   │ 1                                                                   │
-╰─────────────────────┴─────────────────────────────────────────────────────────────────────╯
-
-✓ Trusted Computing Base (TCB) Information:
-╭───────────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────╮
-├───────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ Mrtd              │ c68518a0ebb42136c12b2275164f8c72f25fa9a34392228687ed6e9caeb9c0f1dbd895e9cf475121c029dc47e70e91fd    │
-├───────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ Rootfs Hash       │ 7458d2859b90c071be1f8af3adf4285b764d0c9d08a442be98ff96bb6b160a019db5fbd74edde26095bb659db7a27ab2    │
-├───────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ Rtmr0             │ 79207fa707c5bbf697d579bbd44c2ba14f8565d528aff0de407c58fd34815b67a35cfbb0a0d996b1c7b911a2c8ae806c    │
-├───────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ Rtmr1             │ 4a7db64a609c77e85f603c23e9a9fd03bfd9e6b52ce527f774a598e66d58386026cea79b2aea13b81a0b70cfacdec0ca    │
-├───────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ Rtmr2             │ 8a4fe048fea22663152ef128853caa5c033cbe66baf32ba1ff7f6b1afc1624c279f50a4cbc522a735ca6f69551e61ef2    │
-├───────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ Rtmr3             │ 7b59d1740c489a43ed83b6cc7480edf987a3188b5b19166b2a971018e13304b80406bad2a9ec804d091a764a0ba3d3af    │
-├───────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ Event Log Entries │ 25 entries                                                                                          │
-╰───────────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────╯
-
-✓ Event Log (Showing entries to reproduce RTMR3):
-╭──────────────┬─────┬───────────┬──────────────────────────────────────────────────────────────────╮
-│ Event        │ IMR │ Type      │ Payload                                                          │
-├──────────────┼─────┼───────────┼──────────────────────────────────────────────────────────────────┤
-│ rootfs-hash  │ 3   │ 134217729 │ 2ec914e7be46b48eb4184959cafc524b9c08583a22cacccaa3c66a3938ca03c1 │
-│ app-id       │ 3   │ 134217729 │ 5592440286f5947743f58975a8335459d6fee5cd                         │
-│ compose-hash │ 3   │ 134217729 │ 5592440286f5947743f58975a8335459d6fee5cd9dbcd97a20cf85a58b1bdf82 │
-│ ca-cert-hash │ 3   │ 134217729 │ d2d9c7c29e3f18e69cba87438cef21eea084c2110858230cd39c5decc629a958 │
-│ instance-id  │ 3   │ 134217729 │ 19b555ea772e0d56ebaf75091193ecf4ba603f04                         │
-╰──────────────┴─────┴───────────┴──────────────────────────────────────────────────────────────────╯
-Total: 5 rows
-ℹ To see all full attestation data, use --json
-
-✓ To reproduce RTMR3, use the tool at https://rtmr3-calculator.vercel.app/
-```
-
-</details>
-
-* Start a CVM
-
-```bash
-phala cvms start app_00c6b8e73822fc86f64f2335d6812081d5ba2beb
-```
-
-<details>
-
-<summary>Example Output</summary>
-
-```bash
-⟳ Fetching available CVMs... ✓
-✔ Select a CVM: suh (00c6b8e73822fc86f64f2335d6812081d5ba2beb) - Status: stopped
-⟳ Starting CVM with App ID app_00c6b8e73822fc86f64f2335d6812081d5ba2beb... ✓
-
-╭────────────┬─────────────────────────────────────────────────╮
-├────────────┼─────────────────────────────────────────────────┤
-│ CVM ID     │ 2936                                            │
-├────────────┼─────────────────────────────────────────────────┤
-│ Name       │ suh                                             │
-├────────────┼─────────────────────────────────────────────────┤
-│ Status     │ starting                                        │
-├────────────┼─────────────────────────────────────────────────┤
-│ App ID     │ app_00c6b8e73822fc86f64f2335d6812081d5ba2beb    │
-╰────────────┴─────────────────────────────────────────────────╯
-
-✓ Your CVM is being started. You can check the dashboard for more details:
-https://cloud.phala.com/dashboard/cvms/app_00c6b8e73822fc86f64f2335d6812081d5ba2beb
-```
-
-</details>
-
-* Stop a CVM
-
-```bash
-phala cvms stop app_00c6b8e73822fc86f64f2335d6812081d5ba2beb
-```
-
-<details>
-
-<summary>Example Output</summary>
-
-```bash
-⟳ Fetching available CVMs... ✓
-✔ Select a CVM: suh (00c6b8e73822fc86f64f2335d6812081d5ba2beb) - Status: running
-⟳ Stopping CVM with App ID app_00c6b8e73822fc86f64f2335d6812081d5ba2beb... ✓
-╭────────────┬─────────────────────────────────────────────────╮
-├────────────┼─────────────────────────────────────────────────┤
-│ CVM ID     │ 2936                                            │
-├────────────┼─────────────────────────────────────────────────┤
-│ Name       │ suh                                             │
-├────────────┼─────────────────────────────────────────────────┤
-│ Status     │ stopped                                         │
-├────────────┼─────────────────────────────────────────────────┤
-│ App ID     │ app_00c6b8e73822fc86f64f2335d6812081d5ba2beb    │
-╰────────────┴─────────────────────────────────────────────────╯
-
-✓ Your CVM is being stopped. You can check the dashboard for more details:
-https://cloud.phala.com/dashboard/cvms/app_00c6b8e73822fc86f64f2335d6812081d5ba2beb
-```
-
-</details>
-
-* Delete a CVM
-
-```bash
-phala cvms delete app_5592440286f5947743f58975a8335459d6fee5cd
-```
-
-<details>
-
-<summary>Example Output</summary>
-
-```bash
-⟳ Fetching available CVMs... ✓
-✔ Select a CVM: hell (5592440286f5947743f58975a8335459d6fee5cd) - Status: running
-✔ Are you sure you want to delete CVM with App ID app_5592440286f5947743f58975a8335459d6fee5cd? This action cannot be undone. Yes
-⟳ Deleting CVM app_5592440286f5947743f58975a8335459d6fee5cd... ✓
-✓ CVM app_5592440286f5947743f58975a8335459d6fee5cd deleted successfully
-```
-
-</details>
-
-* Resize a CVM
-
-```bash
-phala cvms resize app_00c6b8e73822fc86f64f2335d6812081d5ba2beb
-```
-
-<details>
-
-<summary>Example Output</summary>
-
-```bash
-⟳ Fetching available CVMs... ✓
-✔ Select a CVM: suh (00c6b8e73822fc86f64f2335d6812081d5ba2beb) - Status: running
-✔ Enter number of vCPUs: 1
-✔ Enter memory in MB: 1024
-✔ Enter disk size in GB: 10
-✔ Allow restart of the CVM if needed for resizing? Yes
-╭───────────────┬───────────────────────╮
-├───────────────┼───────────────────────┤
-│ VCPUs         │ 2 -> 1                │
-├───────────────┼───────────────────────┤
-│ Memory        │ 4096 MB -> 1024 MB    │
-├───────────────┼───────────────────────┤
-│ Disk Size     │ 40 GB -> 10 GB        │
-├───────────────┼───────────────────────┤
-│ Allow Restart │ Yes                   │
-╰───────────────┴───────────────────────╯
-✔ Are you sure you want to resize CVM app_00c6b8e73822fc86f64f2335d6812081d5ba2beb with the following changes:
- Yes
-
-✓ Your CVM is being resized. You can check the dashboard for more details:
-https://cloud.phala.com/dashboard/cvms/app_00c6b8e73822fc86f64f2335d6812081d5ba2beb
-```
-
-</details>
-
-* Restart a CVM
-
-```bash
-phala cvms restart app_00c6b8e73822fc86f64f2335d6812081d5ba2beb
-```
-
-<details>
-
-<summary>Example Output</summary>
-
-```bash
-⟳ Fetching available CVMs... ✓
-✔ Select a CVM: suh (00c6b8e73822fc86f64f2335d6812081d5ba2beb) - Status: stopped
-⟳ Fetching current configuration for CVM app_00c6b8e73822fc86f64f2335d6812081d5ba2beb... ✓
-✔ Enter the path to your Docker Compose file: examples/timelock-nts/docker-compose.yml
-✓ Deleted DSTACK_SIMULATOR_ENDPOINT from current process
-⟳ Upgrading CVM app_00c6b8e73822fc86f64f2335d6812081d5ba2beb... ✓
-ℹ Details: Accepted
-
-✓ Your CVM is being upgraded. You can check the dashboard for more details:
-https://cloud.phala.com/dashboard/cvms/app_00c6b8e73822fc86f64f2335d6812081d5ba2beb
-```
-
-</details>

--- a/phala-cloud/references/phala-cloud-cli/phala/deploy.mdx
+++ b/phala-cloud/references/phala-cloud-cli/phala/deploy.mdx
@@ -1,0 +1,107 @@
+---
+title: "deploy"
+description: "Create a new CVM with on-chain KMS in one step."
+---
+
+## Command: `phala deploy`
+
+### Syntax
+
+```
+phala deploy [options]
+```
+
+### Description
+
+Create a new CVM with on-chain KMS in one step.
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--uuid <value>` | [DEPRECATED] Use --cvm-id instead. CVM UUID. |
+| `--json, --no-json` | Output in JSON format |
+| `--debug` | Enable debug logging |
+| `-n, --name <value>` | Name of the CVM |
+| `-c, --compose <value>` | Path to Docker Compose file (default: docker-compose.yml in current directory) |
+| `--vcpu <value>` | Number of vCPUs (optional, auto-matched if not specified), default is 1 |
+| `--memory <value>` | Memory with optional unit (optional, auto-matched if not specified), e.g., 2G, 1024MB, default is 2048MB |
+| `--disk-size <value>` | Disk size with optional unit (optional, auto-matched if not specified), e.g., 50G, 100GB, default is 40GB |
+| `--image <value>` | OS image version (optional, auto-selected if not specified) |
+| `-r, --region <value>` | Preferred region (e.g., us-west, eu-central). Optional - auto-selected if not specified. |
+| `--node-id <value>` | Node ID (optional, auto-selected if not specified) |
+| `-e, --env <value>` | Environment variable (KEY=VALUE) or path to env file. Can be specified multiple times. |
+| `-i, --interactive` | Enable interactive mode for required parameters |
+| `--kms-id <value>` | KMS ID to use. |
+| `--private-key <value>` | Private key for signing transactions. |
+| `--rpc-url <value>` | RPC URL for the blockchain. |
+| `--wait` | Wait for CVM to complete deployment/update before returning (only applies to updates) |
+| `--ssh-pubkey <value>` | Path to SSH public key file (default: ~/.ssh/id_rsa.pub) |
+| `--dev-os` | Use development OS image (requires SSH public key) |
+| `--non-dev-os` | Use non-development OS image (SSH public key only if explicitly specified) |
+
+### Examples
+
+* Deploy with auto-selection (simplest)
+
+```bash
+phala deploy
+```
+
+* Deploy with environment variables
+
+```bash
+phala deploy -e NODE_ENV=production -e DEBUG=true
+```
+
+* Deploy with env file
+
+```bash
+phala deploy -e .env
+```
+
+* Deploy with env file and overrides
+
+```bash
+phala deploy -e .env -e NODE_ENV=production
+```
+
+* Deploy with specific instance type
+
+```bash
+phala deploy --instance-type tdx.medium
+```
+
+* Deploy to specific region
+
+```bash
+phala deploy --region us-west
+```
+
+* Deploy with instance type and region
+
+```bash
+phala deploy --instance-type tdx.small --region eu-central
+```
+
+* Deploy with manual resource specs
+
+```bash
+phala deploy --vcpu 4 --memory 8G --disk-size 100G
+```
+
+* Deploy with on-chain KMS
+
+```bash
+phala deploy --kms-id ethereum --private-key <key> --rpc-url <url>
+```
+
+* Deploy to specific node (advanced)
+
+```bash
+phala deploy --node-id 6
+```
+

--- a/phala-cloud/references/phala-cloud-cli/phala/docker.mdx
+++ b/phala-cloud/references/phala-cloud-cli/phala/docker.mdx
@@ -1,185 +1,45 @@
 ---
-description: Deploy confidential applications with Phala Cloud's managed TEE infrastructure.
-title: docker
+title: "docker"
+description: "Login to Docker Hub and manage Docker images"
 ---
 
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
 
-## Command: docker
+## Command: `phala docker`
 
-#### Syntax
+### Syntax
 
 ```
-phala docker [options] [command]
+phala docker <command> [options]
 ```
 
 ### Description
 
-The `phala docker`  command is used to your Docker images. Using this tool is optional, and it is okay to use the native docker CLI instead.
-
-```bash
-Usage: phala docker [options] [command]
-
 Login to Docker Hub and manage Docker images
 
-Options:
-  -h, --help          display help for command
+### Options
 
-Commands:
-  login [options]     Login to Docker Hub
-  build [options]     Build a Docker image
-  push [options]      Push a Docker image to Docker Hub
-  generate [options]  Generate a Docker Compose file
-  help [command]      display help for command
-```
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+
+### Subcommands
+
+| Command | Description |
+| ------- | ----------- |
+| `login` | Login to Docker Hub |
+| `build` | Build a Docker image |
+| `push` | Push a Docker image to Docker Hub |
+| `generate` | Generate a Docker Compose file |
+| `run` | Run a Docker Compose setup |
 
 ### Examples
 
-* Display help
+* Display help:
 
 ```bash
 phala docker --help
 ```
-
-* Login to Docker
-
-> Note that the login will use the existing docker login session and will not require another login attempt.
-
-```bash
-phala docker login --username hashwarlock
-```
-
-<details>
-
-<summary>Example Output</summary>
-
-```bash
-⟳ Logging in to Docker Hub as hashwarlock... ✓: Logged in as hashwarlock
-✓ hashwarlock is logged in to Docker Hub
-```
-
-</details>
-
-* Build a Dockerfile
-
-> Note: During the build process, the logs of the build will be output to a file in the root directory of your project in the `.phala-cloud/logs/`folder.
-
-```bash
-phala docker build
-```
-
-<details>
-
-<summary>Example Output</summary>
-
-```bash
-✔ Enter the Docker image name: elizas
-✔ Enter the Docker image tag: v0.0.1o
-✔ Default Dockerfile found at ~/eliza/Dockerfile                                                           │
-✔ Enter the path to your Dockerfile: (Dockerfile)
-Latest 10 lines (full log at ~/eliza/.phala-cloud/logs/elizas-build-2025-03-14T20-43-16-210Z.log):
---------------------------------------------------
-#30 [builder  3/17] RUN apt-get update &&     apt-get install -y curl git python3 make g++ unzip build-essential nodejs &&     apt-get clean &&     rm -rf /var/lib/apt/lists/*
-#30 CACHED
-#31 [stage-1 13/13] COPY --from=builder /app/scripts ./scripts
-#31 CACHED
-#32 exporting to image
-#32 exporting layers done
-#32 writing image sha256:a74b8e777075afd7b09d2107bcbc26cc1f602d81a9cf6491d5d4476cad2a6da4 done
-#32 naming to docker.io/hashwarlock/elizas:v0.0.1o done
-#32 DONE 0.0s
-View build details: docker-desktop://dashboard/build/orbstack/orbstack/gd75239yegh0twa3zkuq1macb
-
-Operation completed. Full log available at: ~eliza/.phala-cloud/logs/elizas-build-2025-03-14T20-43-16-210Z.log
-✓: Docker image hashwarlock/elizas:v0.0.1o built successfully
-✓ Docker image hashwarlock/elizas:v0.0.1o built successfully
-```
-
-</details>
-
-* Push Docker Image to Docker Hub
-
-```bash
-phala docker push --image hashwarlock/elizas:v0.0.1o
-```
-
-<details>
-
-<summary>Example Output</summary>
-
-```bash
-Latest 10 lines (full log at ~/eliza/.phala-cloud/logs/elizas-push-2025-03-14T21-23-14-847Z.log):
---------------------------------------------------
-1de7295ab7c5: Layer already exists
-90e8688db369: Layer already exists
-25d07e7c0ece: Layer already exists
-bcba87ec50fa: Layer already exists
-ba2b458ab48c: Layer already exists
-2ccdaba7f460: Layer already exists
-5bcbf42c7074: Layer already exists
-7ff9bfab192e: Layer already exists
-3e6ae445f28c: Layer already exists
-c0f1022b22a9: Layer already exists
-v0.0.1o: digest: sha256:1fa0685e564d67a451f4e7ce060e95da5ad740d937e69202fcc8957468a66a08 size: 3876
-
-Operation completed. Full log available at: ~/eliza/.phala-cloud/logs/elizas-push-2025-03-14T21-23-14-847Z.log
-✓: Docker image hashwarlock/elizas:v0.0.1o pushed successfully
-✓ Docker image hashwarlock/elizas:v0.0.1o pushed successfully
-```
-
-</details>
-
-* Generate a Basic Docker Compose File
-
-```bash
-phala docker generate --image elizas --tag v0.0.1o -e .env
-```
-
-<details>
-
-<summary>Example Output</summary>
-
-Command Output:
-
-```bash
-✔ File ~/eliza/docker-compose.yml already exists. Overwrite? No
-✔ Enter alternative output path: ~/eliza/docker-generated-compose.yml
-ℹ Generating Docker Compose file for elizas:v0.0.1o using env file: .env
-✓ Backup of docker compose file created at: .phala-cloud/compose/elizas-v0.0.1o-tee-compose.yaml
-✓ Docker Compose file generated successfully: ~/eliza/docker-generated-compose.yml
-```
-
-Generated File:
-
-```yaml
-version: '3.8'
-services:
-  app:
-    image: hashwarlock/elizas:v0.0.1o
-    container_name: app
-    volumes:
-      - /var/run/dstack.sock:/var/run/dstack.sock
-    environment:
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
-      - SERVER_PORT=${SERVER_PORT}
-      - POSTGRES_URL=${POSTGRES_URL}
-      - EVM_CHAINS=${EVM_CHAINS}
-      - BIRDEYE_API_KEY=${BIRDEYE_API_KEY}
-      - COMMUNITY_MANAGER_DISCORD_APPLICATION_ID=${COMMUNITY_MANAGER_DISCORD_APPLICATION_ID}
-      - COMMUNITY_MANAGER_DISCORD_API_TOKEN=${COMMUNITY_MANAGER_DISCORD_API_TOKEN}
-      - SOCIAL_MEDIA_MANAGER_DISCORD_APPLICATION_ID=${SOCIAL_MEDIA_MANAGER_DISCORD_APPLICATION_ID}
-      - SOCIAL_MEDIA_MANAGER_DISCORD_API_TOKEN=${SOCIAL_MEDIA_MANAGER_DISCORD_API_TOKEN}
-      - LIAISON_DISCORD_APPLICATION_ID=${LIAISON_DISCORD_APPLICATION_ID}
-      - LIAISON_DISCORD_API_TOKEN=${LIAISON_DISCORD_API_TOKEN}
-      - PROJECT_MANAGER_DISCORD_APPLICATION_ID=${PROJECT_MANAGER_DISCORD_APPLICATION_ID}
-      - PROJECT_MANAGER_DISCORD_API_TOKEN=${PROJECT_MANAGER_DISCORD_API_TOKEN}
-      - DEV_SUPPORT_DISCORD_APPLICATION_ID=${DEV_SUPPORT_DISCORD_APPLICATION_ID}
-      - DEV_SUPPORT_DISCORD_API_TOKEN=${DEV_SUPPORT_DISCORD_API_TOKEN}
-      - INVESTMENT_MANAGER_DISCORD_APPLICATION_ID=${INVESTMENT_MANAGER_DISCORD_APPLICATION_ID}
-      - INVESTMENT_MANAGER_DISCORD_API_TOKEN=${INVESTMENT_MANAGER_DISCORD_API_TOKEN}
-    restart: always
-```
-
-
-
-</details>

--- a/phala-cloud/references/phala-cloud-cli/phala/login.mdx
+++ b/phala-cloud/references/phala-cloud-cli/phala/login.mdx
@@ -1,0 +1,39 @@
+---
+title: "login"
+description: "Authenticate with Phala Cloud"
+---
+
+## Command: `phala login`
+
+### Syntax
+
+```
+phala login [options] [<api-key>]
+```
+
+### Description
+
+Authenticate with Phala Cloud
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<api-key>?` | API key for authentication (optional, triggers device flow if not provided) |
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--manual` | Manually enter API key instead of using device flow |
+| `--no-open` | Don't automatically open browser for device flow |
+
+### Examples
+
+* Display help:
+
+```bash
+phala login --help
+```

--- a/phala-cloud/references/phala-cloud-cli/phala/logout.mdx
+++ b/phala-cloud/references/phala-cloud-cli/phala/logout.mdx
@@ -1,0 +1,31 @@
+---
+title: "logout"
+description: "Remove the stored API key"
+---
+
+## Command: `phala logout`
+
+### Syntax
+
+```
+phala logout
+```
+
+### Description
+
+Remove the stored API key
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+
+### Examples
+
+* Display help:
+
+```bash
+phala logout --help
+```

--- a/phala-cloud/references/phala-cloud-cli/phala/nodes.mdx
+++ b/phala-cloud/references/phala-cloud-cli/phala/nodes.mdx
@@ -1,23 +1,23 @@
 ---
-title: "simulator"
-description: "TEE simulator commands"
+title: "nodes"
+description: "List and manage TEE nodes"
 ---
 
 <Note>
 This command is marked as unstable and may change in future releases.
 </Note>
 
-## Command: `phala simulator`
+## Command: `phala nodes`
 
 ### Syntax
 
 ```
-phala simulator <command> [options]
+phala nodes <command> [options]
 ```
 
 ### Description
 
-TEE simulator commands
+List and manage TEE nodes
 
 ### Options
 
@@ -30,13 +30,12 @@ TEE simulator commands
 
 | Command | Description |
 | ------- | ----------- |
-| `start` | Start the TEE simulator |
-| `stop` | Stop the TEE simulator |
+| `list` | List all available worker nodes |
 
 ### Examples
 
 * Display help:
 
 ```bash
-phala simulator --help
+phala nodes --help
 ```

--- a/phala-cloud/references/phala-cloud-cli/phala/overview.mdx
+++ b/phala-cloud/references/phala-cloud-cli/phala/overview.mdx
@@ -1,51 +1,174 @@
 ---
-description: Deploy confidential applications with Phala Cloud's managed TEE infrastructure.
-title: Overview
+title: "Overview"
+description: "Complete reference for the Phala Cloud CLI - deploy and manage confidential applications from the command line."
 ---
 
+The Phala Cloud CLI (`phala`) is a command-line tool for deploying and managing Confidential Virtual Machines (CVMs) on Phala Cloud. It provides commands for authentication, deployment, remote access, and CVM lifecycle management.
 
-## Base Command: `phala`
-
-#### Syntax
-
-```
-phala [options] [command]
-```
-
-### Description
-
-The `phala` base command is used to interact with Phala Cloud and manage your deployments from the command line interface.
+## Installation
 
 ```bash
-Phala Cloud CLI - Manage your Phala Cloud Deployments
-
-Options:
-  -V, --version   output the version number
-  -h, --help      display help for command
-
-Commands:
-  auth            Authenticate with Phala Cloud
-  cvms            Manage Phala Confidential Virtual Machines (CVMs)
-  docker          Login to Docker Hub and manage Docker images
-  simulator       TEE simulator commands
-  help [command]  display help for command
+npm install -g phala
 ```
 
-### Examples
+Verify installation:
 
-*   Display help:
+```bash
+phala --version
+```
 
-    ```bash
-    phala --help
-    ```
-*   Check version:
+## Update
 
-    ```bash
-    phala --version
-    ```
-*   Display help for subcommand
+```bash
+npm update -g phala
+```
 
-    ```bash
-    phala help auth
-    ```
+## Quick Start
 
+```bash
+# 1. Authenticate with your API key
+phala login
+
+# 2. Deploy your application
+phala deploy
+
+# 3. Check deployment status
+phala status
+```
+
+## Command Overview
+
+### Authentication
+
+| Command | Description |
+| ------- | ----------- |
+| [`login`](/phala-cloud/references/phala-cloud-cli/phala/login) | Authenticate with Phala Cloud |
+| [`logout`](/phala-cloud/references/phala-cloud-cli/phala/logout) | Remove stored credentials |
+| [`status`](/phala-cloud/references/phala-cloud-cli/phala/status) | Check authentication and account status |
+
+### Deployment
+
+| Command | Description |
+| ------- | ----------- |
+| [`deploy`](/phala-cloud/references/phala-cloud-cli/phala/deploy) | Create or update a CVM with Docker Compose |
+
+### CVM Management
+
+| Command | Description |
+| ------- | ----------- |
+| [`cvms`](/phala-cloud/references/phala-cloud-cli/phala/cvms) | List, inspect, start, stop, restart, and delete CVMs |
+
+### Remote Access
+
+| Command | Description |
+| ------- | ----------- |
+| [`ssh`](/phala-cloud/references/phala-cloud-cli/phala/ssh) | Connect to a CVM via SSH |
+| [`cp`](/phala-cloud/references/phala-cloud-cli/phala/cp) | Copy files to/from a CVM via SCP |
+
+### Docker Integration
+
+| Command | Description |
+| ------- | ----------- |
+| [`docker`](/phala-cloud/references/phala-cloud-cli/phala/docker) | Build, push images and generate Docker Compose files |
+
+### Local Development
+
+| Command | Description |
+| ------- | ----------- |
+| [`simulator`](/phala-cloud/references/phala-cloud-cli/phala/simulator) | Run a local TEE simulator for development |
+
+### Configuration
+
+| Command | Description |
+| ------- | ----------- |
+| [`config`](/phala-cloud/references/phala-cloud-cli/phala/config) | Manage local CLI configuration |
+| [`nodes`](/phala-cloud/references/phala-cloud-cli/phala/nodes) | List available TEE worker nodes |
+
+## Global Options
+
+These options are available for all commands:
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help for the current command |
+| `-v, --version` | Show CLI version |
+
+## Configuration File
+
+The CLI reads configuration from `phala.toml` in your project directory. This file stores deployment settings:
+
+```toml
+# phala.toml
+name = "my-app"
+cvm_id = "app_abc123def456"
+gateway_domain = "dstack-prod5.phala.network"
+gateway_port = 443
+```
+
+When `phala.toml` exists, commands like `deploy`, `ssh`, and `cp` use these values as defaults.
+
+## Shell Completion
+
+Generate shell completion scripts for your shell:
+
+```bash
+# Bash
+phala completion --shell bash >> ~/.bashrc
+
+# Zsh
+phala completion --shell zsh >> ~/.zshrc
+
+# Fish
+phala completion --shell fish > ~/.config/fish/completions/phala.fish
+```
+
+## Environment Variables
+
+| Variable | Description |
+| -------- | ----------- |
+| `PHALA_API_TOKEN` | API token for authentication (alternative to `phala login`) |
+
+## Common Workflows
+
+### Deploy a new application
+
+```bash
+# Create docker-compose.yml in your project
+phala deploy --name my-app --region us-west
+```
+
+### Update an existing deployment
+
+```bash
+# Re-run deploy to update (uses phala.toml settings)
+phala deploy
+```
+
+### Debug a running CVM
+
+```bash
+# Connect via SSH
+phala ssh my-app
+
+# View container logs
+phala cvms logs my-app
+
+# View VM serial logs
+phala cvms serial-logs my-app
+```
+
+### Copy files to/from CVM
+
+```bash
+# Upload a file
+phala cp ./config.json my-app:/app/config.json
+
+# Download a file
+phala cp my-app:/app/data.json ./data.json
+```
+
+## See Also
+
+- [Getting Started with the CLI](/phala-cloud/phala-cloud-cli/start-from-cloud-cli)
+- [CI/CD Integration](/phala-cloud/phala-cloud-cli/ci-cd-automation/setup-a-ci-cd-pipeline)
+- [CVM Overview](/phala-cloud/cvm/overview)

--- a/phala-cloud/references/phala-cloud-cli/phala/overview.mdx
+++ b/phala-cloud/references/phala-cloud-cli/phala/overview.mdx
@@ -32,8 +32,8 @@ phala login
 # 2. Deploy your application
 phala deploy
 
-# 3. Check deployment status
-phala status
+# 3. Check your CVM
+phala cvms get
 ```
 
 ## Command Overview

--- a/phala-cloud/references/phala-cloud-cli/phala/ssh.mdx
+++ b/phala-cloud/references/phala-cloud-cli/phala/ssh.mdx
@@ -1,11 +1,15 @@
 ---
-description: Connect to a CVM via SSH through the secure gateway tunnel.
-title: ssh
+title: "ssh"
+description: "Connect to a CVM via SSH"
 ---
 
-## Command: `ssh`
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
 
-#### Syntax
+## Command: `phala ssh`
+
+### Syntax
 
 ```
 phala ssh [options] [<cvm-name>] [--] [...]
@@ -13,114 +17,83 @@ phala ssh [options] [<cvm-name>] [--] [...]
 
 ### Description
 
-The `phala ssh` command connects you to a CVM via SSH through the secure gateway tunnel. It handles all the gateway configuration automatically.
-
-```bash
-Usage: phala ssh [options] [<cvm-name>] [--] [...]
-
 Connect to a CVM via SSH
 
-Arguments:
-  <cvm-name>?       CVM name. If not provided, reads from phala.toml
+### Arguments
 
-Options:
-  -h, --help              Show help information
-  -p, --port <value>      Gateway port (default: 443)
-  -g, --gateway <value>   Gateway domain (skips API call for offline usage)
-  -t, --timeout <value>   Connection timeout in seconds (default: 30)
-  -v, --verbose           Show verbose connection details
-  --dry-run               Print the SSH command without executing it
+| Argument | Description |
+| -------- | ----------- |
+| `<cvm-name>?` | CVM name. If not provided, reads from phala.toml |
 
-Pass-through (after --):
-  All arguments after -- are passed directly to ssh.
-```
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `-p, --port <value>` | Gateway port. Priority: CLI option > phala.toml gateway_port > 443 |
+| `-g, --gateway <value>` | Gateway domain. Priority: CLI option > phala.toml gateway_domain > API. When specified, skips API call for offline usage |
+| `-t, --timeout <value>` | Connection timeout in seconds (default: 30) |
+| `-v, --verbose` | Show verbose connection details |
+| `--dry-run` | Print the SSH command without executing it |
+
+### Pass-through Arguments
+
+All arguments after -- are passed directly to ssh. Common options: -i (identity file), -L (local forward), -R (remote forward), -D (SOCKS proxy), -N (no command), -v (ssh verbose). Any trailing arguments are executed as remote command. Note: -o ProxyCommand is blocked.
 
 ### Examples
 
-* Connect using phala.toml configuration
+* Connect using configuration from phala.toml
 
 ```bash
 phala ssh
 ```
 
-* Connect to a specific CVM
+* Connect to a specific CVM (queries API for gateway)
 
 ```bash
-phala ssh my-app
+phala ssh app_123
 ```
 
-* Preview the SSH command without connecting
+* Offline mode: connect without API (using phala.toml gateway)
 
 ```bash
-phala ssh my-app --dry-run
+phala ssh app_123 -g dstack-prod5.phala.network -p 16185
 ```
 
-<details>
-
-<summary>Example Output</summary>
+* Connect with custom SSH key
 
 ```bash
-ssh -o ProxyCommand="openssl s_client -quiet -connect %h:%p" \
-    -o StrictHostKeyChecking=no \
-    root@abc123def456-22.dstack-prod5.phala.network -p 443
+phala ssh app_123 -- -i ~/.ssh/custom_key
 ```
 
-</details>
+* Forward local port 8080 to remote port 80
+
+```bash
+phala ssh app_123 -- -L 8080:localhost:80
+```
+
+* SOCKS proxy without remote command
+
+```bash
+phala ssh app_123 -- -D 1080 -N
+```
+
+* Execute remote command
+
+```bash
+phala ssh app_123 -- ls -la /app
+```
 
 * Connect with verbose output for debugging
 
 ```bash
-phala ssh my-app -v
+phala ssh app_123 -v
 ```
 
-* Forward a local port to the CVM
+* Print the SSH command without executing
 
 ```bash
-phala ssh my-app -- -L 8080:localhost:80
+phala ssh app_123 --dry-run -- -L 8080:localhost:80
 ```
 
-This forwards your local port 8080 to port 80 on the CVM.
-
-* Set up a SOCKS proxy
-
-```bash
-phala ssh my-app -- -D 1080 -N
-```
-
-This creates a SOCKS proxy on local port 1080 without executing a remote command.
-
-* Execute a remote command
-
-```bash
-phala ssh my-app -- docker ps -a
-```
-
-* Connect with a custom SSH key
-
-```bash
-phala ssh my-app -- -i ~/.ssh/custom_key
-```
-
-* Offline mode (skip API lookup)
-
-```bash
-phala ssh my-app -g dstack-prod5.phala.network -p 443
-```
-
-When you specify the gateway domain, the CLI skips the API call and connects directly.
-
-### Pass-through Options
-
-Any arguments after `--` are passed directly to the underlying SSH command. Common options include:
-
-| Option | Description |
-|--------|-------------|
-| `-i <keyfile>` | Use a specific identity file |
-| `-L <local>:<remote>` | Local port forwarding |
-| `-R <remote>:<local>` | Remote port forwarding |
-| `-D <port>` | Dynamic SOCKS proxy |
-| `-v` | SSH verbose mode |
-
-<Note>
-The `-o ProxyCommand` option is blocked since the CLI manages the proxy configuration automatically.
-</Note>

--- a/phala-cloud/references/phala-cloud-cli/phala/status.mdx
+++ b/phala-cloud/references/phala-cloud-cli/phala/status.mdx
@@ -1,0 +1,40 @@
+---
+title: "status"
+description: "Check Phala Cloud status and authentication"
+---
+
+## Command: `phala status`
+
+### Syntax
+
+```
+phala status [options]
+```
+
+### Description
+
+Check Phala Cloud status and authentication
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `-j, --json, --no-json` | Output in JSON format |
+| `-d, --debug` | Enable debug output |
+
+### Examples
+
+* Show login status in human-readable format
+
+```bash
+phala status
+```
+
+* Get status as JSON
+
+```bash
+phala status --json
+```
+

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,65 @@
+# Documentation Generation Scripts
+
+## CLI Reference Generator
+
+Generates MDX documentation files from `phala --help` output. This ensures the CLI reference documentation stays in sync with the actual CLI.
+
+### Usage
+
+From the repository root:
+
+```bash
+node scripts/generate-cli-docs.js
+```
+
+### What it does
+
+1. Runs `npx phala --help` to discover all CLI commands
+2. For each command, runs `npx phala <command> --help` to get detailed information
+3. Parses the help output to extract:
+   - Command description and usage syntax
+   - Options with their flags and descriptions
+   - Subcommands with status indicators (Deprecated, Unstable)
+   - Command examples
+   - Arguments and pass-through options
+4. Generates MDX files in `phala-cloud/references/phala-cloud-cli/phala/`
+5. Updates `docs.json` navigation with the correct page order
+
+### Output files
+
+The script generates/updates these files (except `overview.mdx` which is preserved):
+
+- `phala-cloud/references/phala-cloud-cli/phala/overview.mdx` - Main CLI reference
+- `phala-cloud/references/phala-cloud-cli/phala/login.mdx`
+- `phala-cloud/references/phala-cloud-cli/phala/logout.mdx`
+- `phala-cloud/references/phala-cloud-cli/phala/status.mdx`
+- `phala-cloud/references/phala-cloud-cli/phala/deploy.mdx`
+- `phala-cloud/references/phala-cloud-cli/phala/cvms.mdx`
+- `phala-cloud/references/phala-cloud-cli/phala/ssh.mdx`
+- `phala-cloud/references/phala-cloud-cli/phala/cp.mdx`
+- `phala-cloud/references/phala-cloud-cli/phala/docker.mdx`
+- `phala-cloud/references/phala-cloud-cli/phala/simulator.mdx`
+- `phala-cloud/references/phala-cloud-cli/phala/nodes.mdx`
+- `phala-cloud/references/phala-cloud-cli/phala/config.mdx`
+- `phala-cloud/references/phala-cloud-cli/phala/auth.mdx` (deprecated)
+
+### Preserved files
+
+Some files are manually edited and won't be overwritten by the script:
+
+- `overview.mdx` - Contains the polished CLI manual with installation, quick start, and workflow examples
+
+To add a file to the preserve list, edit `PRESERVE_FILES` in `generate-cli-docs.js`.
+
+### When to run
+
+Run this script when:
+
+- The Phala CLI is updated with new commands or options
+- Command descriptions or examples change
+- You want to ensure docs match the current CLI version
+
+### Requirements
+
+- Node.js
+- `phala` CLI (installed via `npx phala`)

--- a/scripts/generate-cli-docs.js
+++ b/scripts/generate-cli-docs.js
@@ -1,0 +1,568 @@
+#!/usr/bin/env node
+
+/**
+ * CLI Documentation Generator for Phala Cloud CLI
+ *
+ * Generates MDX documentation files from `phala --help` output.
+ * Run: node scripts/generate-cli-docs.js
+ */
+
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+// Configuration - use process.cwd() for portability
+const ROOT_DIR = process.cwd();
+const OUTPUT_DIR = path.join(
+  ROOT_DIR,
+  "phala-cloud/references/phala-cloud-cli/phala"
+);
+const DOCS_JSON_PATH = path.join(ROOT_DIR, "docs.json");
+
+// Commands to skip (deprecated or internal)
+const SKIP_COMMANDS = new Set(["help", "completion"]);
+
+// Files to preserve (manually edited, not auto-generated)
+// These files won't be overwritten but will still be included in docs.json
+const PRESERVE_FILES = new Set(["overview"]);
+
+// Commands that are deprecated but should redirect to new commands
+const DEPRECATED_REDIRECTS = {
+  auth: "Use `phala login`, `phala logout`, and `phala status` instead.",
+};
+
+/**
+ * Execute a command and return its output
+ */
+function runCommand(args) {
+  try {
+    const command = `npx phala ${args.join(" ")} --help 2>&1`;
+    return execSync(command, { encoding: "utf-8", timeout: 30000 });
+  } catch (error) {
+    if (error.stdout) {
+      return error.stdout;
+    }
+    console.error(`Failed to run: phala ${args.join(" ")} --help`);
+    return "";
+  }
+}
+
+/**
+ * Parse the help output into a structured Command object
+ */
+function parseHelpOutput(output, commandPath) {
+  const lines = output.split("\n");
+
+  const command = {
+    name: commandPath[commandPath.length - 1] || "phala",
+    description: "",
+    usage: "",
+    options: [],
+    subcommands: [],
+    examples: [],
+    arguments: [],
+    passThrough: null,
+    deprecated: false,
+    unstable: false,
+  };
+
+  let section = "";
+  let currentExample = "";
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmedLine = line.trim();
+
+    // Parse usage line
+    if (trimmedLine.startsWith("Usage:")) {
+      command.usage = trimmedLine.replace("Usage:", "").trim();
+      continue;
+    }
+
+    // Parse description (line after usage, before sections)
+    if (
+      command.usage &&
+      !command.description &&
+      trimmedLine &&
+      !trimmedLine.endsWith(":") &&
+      !trimmedLine.startsWith("-") &&
+      !trimmedLine.startsWith("<") &&
+      section === ""
+    ) {
+      command.description = trimmedLine;
+      // Check for deprecated/unstable markers
+      if (command.description.includes("[DEPRECATED]")) {
+        command.deprecated = true;
+        command.description = command.description
+          .replace("[DEPRECATED]", "")
+          .trim();
+      }
+      if (command.description.includes("[UNSTABLE]")) {
+        command.unstable = true;
+        command.description = command.description
+          .replace("[UNSTABLE]", "")
+          .trim();
+      }
+      continue;
+    }
+
+    // Detect section headers
+    if (trimmedLine === "Available commands:") {
+      section = "commands";
+      continue;
+    }
+    if (
+      trimmedLine === "Options:" ||
+      trimmedLine === "Global options:" ||
+      trimmedLine === "Global Options:"
+    ) {
+      section = "options";
+      continue;
+    }
+    if (trimmedLine === "Arguments:") {
+      section = "arguments";
+      continue;
+    }
+    if (trimmedLine === "Examples:") {
+      section = "examples";
+      continue;
+    }
+    if (trimmedLine.startsWith("Pass-through")) {
+      section = "passthrough";
+      command.passThrough = "";
+      continue;
+    }
+
+    // Parse sections
+    if (section === "commands" && trimmedLine) {
+      // Format: "  command-name    Description [DEPRECATED]"
+      const match = trimmedLine.match(
+        /^(\S+)\s+(.+?)(?:\s+\[(DEPRECATED|UNSTABLE)\])?(?:\s+\[(DEPRECATED|UNSTABLE)\])?$/
+      );
+      if (match) {
+        const subCmd = {
+          name: match[1],
+          description: match[2].trim(),
+          deprecated: false,
+          unstable: false,
+        };
+        if (
+          trimmedLine.includes("[DEPRECATED]") ||
+          match[3] === "DEPRECATED" ||
+          match[4] === "DEPRECATED"
+        ) {
+          subCmd.deprecated = true;
+        }
+        if (
+          trimmedLine.includes("[UNSTABLE]") ||
+          match[3] === "UNSTABLE" ||
+          match[4] === "UNSTABLE"
+        ) {
+          subCmd.unstable = true;
+        }
+        command.subcommands.push(subCmd);
+      }
+    }
+
+    if (section === "options" && trimmedLine) {
+      // Format variations:
+      // "  -h, --help              Description"
+      // "  --api-token TOKEN, --api-key TOKENAPI token used for authentication"
+      // "  --cvm-id <value>        Description"
+      // "  -n, --name <value>      Description"
+
+      // Look for pattern: flags (with optional value placeholder) followed by 2+ spaces then description
+      const optMatch = trimmedLine.match(/^(-[^\s]+(?:[\s,]+(?:<[^>]+>|\w+|--[^\s]+))*)\s{2,}(.+)$/);
+      if (optMatch) {
+        let flags = optMatch[1].trim();
+        let description = optMatch[2].trim();
+        let defaultValue;
+
+        // Clean up flags - keep only the flag parts, move <value> to description context
+        // For display, format as: --flag <value>
+        const flagParts = flags.split(/,\s*/);
+        const cleanFlags = flagParts.map(part => {
+          // Handle cases like "--cvm-id <value>" or "--api-token TOKEN"
+          return part.trim();
+        }).join(", ");
+
+        // Extract default value if present
+        const defaultMatch = description.match(/\(default:\s*([^)]+)\)/);
+        if (defaultMatch) {
+          defaultValue = defaultMatch[1];
+        }
+
+        command.options.push({
+          flags: cleanFlags,
+          description,
+          defaultValue,
+        });
+      }
+    }
+
+    if (section === "arguments" && trimmedLine) {
+      // Format: "  <arg-name>?     Description"
+      if (trimmedLine.startsWith("<") || trimmedLine.match(/^\S+\s+/)) {
+        command.arguments.push(trimmedLine);
+      }
+    }
+
+    if (section === "examples") {
+      if (trimmedLine.startsWith("#")) {
+        // Comment line, start new example
+        if (currentExample) {
+          command.examples.push(currentExample.trim());
+        }
+        currentExample = trimmedLine + "\n";
+      } else if (trimmedLine.startsWith("phala ")) {
+        currentExample += trimmedLine + "\n";
+      } else if (trimmedLine && currentExample) {
+        currentExample += trimmedLine + "\n";
+      }
+    }
+
+    if (section === "passthrough") {
+      command.passThrough += line + "\n";
+    }
+  }
+
+  // Add last example
+  if (currentExample) {
+    command.examples.push(currentExample.trim());
+  }
+
+  return command;
+}
+
+/**
+ * Generate MDX content for a command
+ */
+function generateMdx(command, commandPath) {
+  const fullCommand = ["phala", ...commandPath.slice(1)].join(" ");
+  let title =
+    commandPath.length > 1
+      ? commandPath[commandPath.length - 1]
+      : "Overview";
+
+  // Add deprecation marker to title
+  if (command.deprecated) {
+    title += " (Deprecated)";
+  }
+
+  let mdx = `---
+title: "${title}"
+description: "${escapeForYaml(command.description || `Reference for the ${fullCommand} command`)}"
+---
+
+`;
+
+  // Add deprecation notice
+  if (command.deprecated) {
+    mdx += `<Warning>
+This command is deprecated. ${DEPRECATED_REDIRECTS[command.name] || "See the newer alternatives."}
+</Warning>
+
+`;
+  }
+
+  // Add unstable notice
+  if (command.unstable) {
+    mdx += `<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+`;
+  }
+
+  // Command header
+  if (commandPath.length > 1) {
+    mdx += `## Command: \`${fullCommand}\`\n\n`;
+  } else {
+    mdx += `## Base Command: \`phala\`\n\n`;
+  }
+
+  // Syntax
+  mdx += `### Syntax\n\n`;
+  mdx += "```\n";
+  mdx += command.usage + "\n";
+  mdx += "```\n\n";
+
+  // Description
+  mdx += `### Description\n\n`;
+  mdx += `${command.description}\n\n`;
+
+  // Arguments
+  if (command.arguments.length > 0) {
+    mdx += `### Arguments\n\n`;
+    mdx += `| Argument | Description |\n`;
+    mdx += `| -------- | ----------- |\n`;
+    for (const arg of command.arguments) {
+      const parts = arg.match(/^(\S+)\s+(.*)$/);
+      if (parts) {
+        mdx += `| \`${parts[1]}\` | ${parts[2]} |\n`;
+      } else {
+        mdx += `| \`${arg}\` | - |\n`;
+      }
+    }
+    mdx += "\n";
+  }
+
+  // Options table
+  if (command.options.length > 0) {
+    mdx += `### Options\n\n`;
+    mdx += `| Option | Description |\n`;
+    mdx += `| ------ | ----------- |\n`;
+    for (const opt of command.options) {
+      const desc = opt.description;
+      mdx += `| \`${opt.flags}\` | ${escapeForTable(desc)} |\n`;
+    }
+    mdx += "\n";
+  }
+
+  // Subcommands tables (separate active from deprecated)
+  if (command.subcommands.length > 0) {
+    const activeSubcommands = command.subcommands.filter(sub => !sub.deprecated);
+    const deprecatedSubcommands = command.subcommands.filter(sub => sub.deprecated);
+
+    // Active subcommands
+    if (activeSubcommands.length > 0) {
+      mdx += `### Subcommands\n\n`;
+      mdx += `| Command | Description |\n`;
+      mdx += `| ------- | ----------- |\n`;
+      for (const sub of activeSubcommands) {
+        mdx += `| \`${sub.name}\` | ${escapeForTable(sub.description)} |\n`;
+      }
+      mdx += "\n";
+    }
+
+    // Deprecated subcommands
+    if (deprecatedSubcommands.length > 0) {
+      mdx += `### Deprecated Subcommands\n\n`;
+      mdx += `| Command | Description |\n`;
+      mdx += `| ------- | ----------- |\n`;
+      for (const sub of deprecatedSubcommands) {
+        mdx += `| \`${sub.name}\` | ${escapeForTable(sub.description)} |\n`;
+      }
+      mdx += "\n";
+    }
+  }
+
+  // Pass-through section
+  if (command.passThrough) {
+    mdx += `### Pass-through Arguments\n\n`;
+    mdx += command.passThrough
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line)
+      .join("\n\n");
+    mdx += "\n\n";
+  }
+
+  // Examples
+  if (command.examples.length > 0) {
+    mdx += `### Examples\n\n`;
+    for (const example of command.examples) {
+      const lines = example.split("\n");
+      for (const line of lines) {
+        if (line.startsWith("#")) {
+          // Comment becomes description
+          mdx += `${line.replace("#", "*").trim()}\n\n`;
+        } else if (line.startsWith("phala ")) {
+          mdx += "```bash\n";
+          mdx += line + "\n";
+          mdx += "```\n\n";
+        }
+      }
+    }
+  } else {
+    // Default examples
+    mdx += `### Examples\n\n`;
+    mdx += `* Display help:\n\n`;
+    mdx += "```bash\n";
+    mdx += `${fullCommand} --help\n`;
+    mdx += "```\n";
+  }
+
+  // Replace placeholder domains with realistic Phala examples
+  // TODO: Remove this workaround once CLI is fixed upstream
+  // See: https://github.com/Phala-Network/phala-cloud/issues/139
+  mdx = mdx.replace(/dstack-gateway\.example\.com/g, "dstack-prod5.phala.network");
+
+  return mdx;
+}
+
+/**
+ * Escape special characters for YAML frontmatter
+ */
+function escapeForYaml(str) {
+  return str.replace(/"/g, '\\"').replace(/\n/g, " ");
+}
+
+/**
+ * Escape special characters for markdown tables
+ */
+function escapeForTable(str) {
+  return str.replace(/\|/g, "\\|").replace(/\n/g, " ");
+}
+
+/**
+ * Get all commands recursively
+ */
+function getAllCommands() {
+  const commands = new Map();
+
+  // Get root command
+  const rootOutput = runCommand([]);
+  const rootCommand = parseHelpOutput(rootOutput, ["phala"]);
+  commands.set("overview", rootCommand);
+
+  console.log(`Found ${rootCommand.subcommands.length} top-level commands`);
+
+  // Get each top-level command
+  for (const subCmd of rootCommand.subcommands) {
+    if (SKIP_COMMANDS.has(subCmd.name)) {
+      console.log(`  Skipping: ${subCmd.name}`);
+      continue;
+    }
+
+    console.log(`  Processing: ${subCmd.name}`);
+    const cmdOutput = runCommand([subCmd.name]);
+    const cmd = parseHelpOutput(cmdOutput, ["phala", subCmd.name]);
+
+    // Inherit deprecated/unstable status from parent's subcommand info
+    if (subCmd.deprecated) cmd.deprecated = true;
+    if (subCmd.unstable) cmd.unstable = true;
+
+    commands.set(subCmd.name, cmd);
+
+    // Get subcommands for this command (for reference in the same page)
+    if (cmd.subcommands.length > 0) {
+      console.log(`    Found ${cmd.subcommands.length} subcommands`);
+    }
+  }
+
+  return commands;
+}
+
+/**
+ * Generate MDX files for all commands
+ */
+function generateMdxFiles(commands) {
+  const generatedFiles = [];
+
+  // Ensure output directory exists
+  if (!fs.existsSync(OUTPUT_DIR)) {
+    fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+  }
+
+  for (const [name, command] of commands) {
+    const filename = `${name}.mdx`;
+    const filepath = path.join(OUTPUT_DIR, filename);
+
+    // Skip preserved files (manually edited)
+    if (PRESERVE_FILES.has(name)) {
+      console.log(`Preserved: ${filepath} (manually edited)`);
+      generatedFiles.push(name);
+      continue;
+    }
+
+    const commandPath = name === "overview" ? ["phala"] : ["phala", name];
+    const mdxContent = generateMdx(command, commandPath);
+    fs.writeFileSync(filepath, mdxContent);
+    console.log(`Generated: ${filepath}`);
+    generatedFiles.push(name);
+  }
+
+  return generatedFiles;
+}
+
+/**
+ * Update docs.json with new CLI pages
+ */
+function updateDocsJson(commandNames) {
+  const docsJson = JSON.parse(fs.readFileSync(DOCS_JSON_PATH, "utf-8"));
+
+  // Define the order of commands
+  const commandOrder = [
+    "overview",
+    "login",
+    "logout",
+    "status",
+    "deploy",
+    "cvms",
+    "ssh",
+    "cp",
+    "docker",
+    "simulator",
+    "nodes",
+    "config",
+    "auth", // deprecated, at the end
+  ];
+
+  // Sort command names by the defined order
+  const sortedNames = commandNames.sort((a, b) => {
+    const aIndex = commandOrder.indexOf(a);
+    const bIndex = commandOrder.indexOf(b);
+    if (aIndex === -1 && bIndex === -1) return a.localeCompare(b);
+    if (aIndex === -1) return 1;
+    if (bIndex === -1) return -1;
+    return aIndex - bIndex;
+  });
+
+  // Build the new pages array
+  const cliPages = sortedNames.map(
+    (name) => `/phala-cloud/references/phala-cloud-cli/phala/${name}`
+  );
+
+  // Find and update the CLI Reference group in docs.json
+  function findAndUpdateCliGroup(obj) {
+    if (Array.isArray(obj)) {
+      for (const item of obj) {
+        if (typeof item === "object" && item !== null) {
+          if (findAndUpdateCliGroup(item)) return true;
+        }
+      }
+    } else if (typeof obj === "object" && obj !== null) {
+      if (obj.group === "CLI Reference") {
+        obj.pages = cliPages;
+        return true;
+      }
+      for (const key of Object.keys(obj)) {
+        const value = obj[key];
+        if (typeof value === "object" && value !== null) {
+          if (findAndUpdateCliGroup(value)) return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  if (findAndUpdateCliGroup(docsJson)) {
+    fs.writeFileSync(DOCS_JSON_PATH, JSON.stringify(docsJson, null, 2) + "\n");
+    console.log(`Updated: ${DOCS_JSON_PATH}`);
+  } else {
+    console.error("Could not find CLI Reference group in docs.json");
+  }
+}
+
+/**
+ * Main function
+ */
+function main() {
+  console.log("Generating CLI documentation from phala --help...\n");
+
+  // Get all commands
+  const commands = getAllCommands();
+  console.log(`\nTotal commands found: ${commands.size}\n`);
+
+  // Generate MDX files
+  const generatedFiles = generateMdxFiles(commands);
+  console.log(`\nGenerated ${generatedFiles.length} MDX files\n`);
+
+  // Update docs.json
+  updateDocsJson(generatedFiles);
+
+  console.log("\nDone! Run 'npx mintlify dev' to preview the documentation.");
+}
+
+main();


### PR DESCRIPTION
## Summary
- Add `scripts/generate-cli-docs.js` to auto-generate CLI reference from `phala --help`
- Generate docs for all CLI commands with proper structure
- Polished overview page with installation, quick start, and workflows
- Separate deprecated subcommands into their own section

## Test plan
- [ ] Run `node scripts/generate-cli-docs.js` to verify generation
- [ ] Run `npx mintlify dev` to preview documentation
- [ ] Verify navigation in docs.json is correct

🤖 Generated with [Claude Code](https://claude.ai/code)