### PR TITLE
docs: add note that ssh/cp require dev-os flag

### DIFF
--- a/phala-cloud/references/phala-cloud-cli/phala/overview.mdx
+++ b/phala-cloud/references/phala-cloud-cli/phala/overview.mdx
@@ -65,6 +65,10 @@ phala cvms get
 | [`ssh`](/phala-cloud/references/phala-cloud-cli/phala/ssh) | Connect to a CVM via SSH |
 | [`cp`](/phala-cloud/references/phala-cloud-cli/phala/cp) | Copy files to/from a CVM via SCP |
 
+<Note>
+SSH and SCP access require deploying with the `--dev-os` flag. See [Enable SSH Access](/phala-cloud/networking/enable-ssh-access) for details.
+</Note>
+
 ### Docker Integration
 
 | Command | Description |


### PR DESCRIPTION
## Summary
- Add note in CLI overview that SSH and SCP access require the `--dev-os` flag
- Link to Enable SSH Access documentation for details

🤖 Generated with [Claude Code](https://claude.ai/code)