### PR TITLE
fix: parse CLI options with no space after <value>

### DIFF
--- a/phala-cloud/references/phala-cloud-cli/phala/deploy.mdx
+++ b/phala-cloud/references/phala-cloud-cli/phala/deploy.mdx
@@ -27,6 +27,7 @@ Create a new CVM with on-chain KMS in one step.
 | `--debug` | Enable debug logging |
 | `-n, --name <value>` | Name of the CVM |
 | `-c, --compose <value>` | Path to Docker Compose file (default: docker-compose.yml in current directory) |
+| `-t, --instance-type <value>` | Instance type (e.g., tdx.small, tdx.medium, tdx.large). Optional - auto-selected if not specified. |
 | `--vcpu <value>` | Number of vCPUs (optional, auto-matched if not specified), default is 1 |
 | `--memory <value>` | Memory with optional unit (optional, auto-matched if not specified), e.g., 2G, 1024MB, default is 2048MB |
 | `--disk-size <value>` | Disk size with optional unit (optional, auto-matched if not specified), e.g., 50G, 100GB, default is 40GB |
@@ -36,6 +37,7 @@ Create a new CVM with on-chain KMS in one step.
 | `-e, --env <value>` | Environment variable (KEY=VALUE) or path to env file. Can be specified multiple times. |
 | `-i, --interactive` | Enable interactive mode for required parameters |
 | `--kms-id <value>` | KMS ID to use. |
+| `--pre-launch-script <value>` | Path to pre-launch script |
 | `--private-key <value>` | Private key for signing transactions. |
 | `--rpc-url <value>` | RPC URL for the blockchain. |
 | `--wait` | Wait for CVM to complete deployment/update before returning (only applies to updates) |

--- a/scripts/generate-cli-docs.js
+++ b/scripts/generate-cli-docs.js
@@ -170,9 +170,17 @@ function parseHelpOutput(output, commandPath) {
       // "  --api-token TOKEN, --api-key TOKENAPI token used for authentication"
       // "  --cvm-id <value>        Description"
       // "  -n, --name <value>      Description"
+      // "  -t, --instance-type <value>Instance type..." (no space between <value> and description)
 
       // Look for pattern: flags (with optional value placeholder) followed by 2+ spaces then description
-      const optMatch = trimmedLine.match(/^(-[^\s]+(?:[\s,]+(?:<[^>]+>|\w+|--[^\s]+))*)\s{2,}(.+)$/);
+      let optMatch = trimmedLine.match(/^(-[^\s]+(?:[\s,]+(?:<[^>]+>|\w+|--[^\s]+))*)\s{2,}(.+)$/);
+
+      // Fallback: handle cases where description immediately follows <value> with no space
+      // e.g., "-t, --instance-type <value>Instance type..."
+      if (!optMatch) {
+        optMatch = trimmedLine.match(/^(-[^\s]+(?:,\s*-[^\s]+)?(?:\s+<[^>]+>)?)([A-Z].*)$/);
+      }
+
       if (optMatch) {
         let flags = optMatch[1].trim();
         let description = optMatch[2].trim();


### PR DESCRIPTION
## Summary
- Fix CLI docs generator to handle options where description immediately follows `<value>` with no space
- Adds `--instance-type` and `--pre-launch-script` to deploy.mdx

## Test plan
- [x] Run `node scripts/generate-cli-docs.js`
- [x] Verify `--instance-type` appears in deploy.mdx options table

🤖 Generated with [Claude Code](https://claude.ai/code)