### PR TITLE
docs: add API reference link to Cloud API overview

### DIFF
--- a/phala-cloud/phala-cloud-api/overview.mdx
+++ b/phala-cloud/phala-cloud-api/overview.mdx
@@ -10,6 +10,10 @@ Cloud API is in beta stage and not stabilized yet. Please use it at your own ris
 
 You can use the API to access all the features available on the Phala Cloud platform. It shares the same API as the cloud dashboard frontend.
 
+<Card title="API Reference" icon="book" href="https://cloud-api.phala.com/docs">
+  Browse the full API reference with all available endpoints, request parameters, and response schemas.
+</Card>
+
 You may want to check our Cloud API example that shows the basic operations like creating and manage a CVM here: [https://github.com/Leechael/phala-cloud-api-example](https://github.com/Leechael/phala-cloud-api-example)
 
 ## Error Handling


### PR DESCRIPTION
## Summary
- Add prominent Card link to https://cloud-api.phala.com/docs on the API overview page

## Test plan
- [ ] Verify Card renders correctly on the API overview page
- [ ] Verify link opens the API docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>