### PR TITLE
docs: document deprecated CLI commands and options

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -254,10 +254,15 @@
                     "pages": [
                       "/phala-cloud/phala-cloud-cli/api",
                       "/phala-cloud/phala-cloud-cli/self",
-                      "/phala-cloud/phala-cloud-cli/config",
-                      "/phala-cloud/phala-cloud-cli/docker",
                       "/phala-cloud/phala-cloud-cli/simulator",
                       "/phala-cloud/phala-cloud-cli/completion"
+                    ]
+                  },
+                  {
+                    "group": "Deprecated",
+                    "pages": [
+                      "/phala-cloud/phala-cloud-cli/config",
+                      "/phala-cloud/phala-cloud-cli/docker"
                     ]
                   },
                   {

--- a/phala-cloud/phala-cloud-cli/config.mdx
+++ b/phala-cloud/phala-cloud-cli/config.mdx
@@ -1,7 +1,11 @@
 ---
-title: "phala config"
+title: "phala config (Deprecated)"
 description: "Manage local CLI configuration values."
 ---
+
+<Warning>
+`phala config` is deprecated. The CLI now uses profile-based credentials stored in `~/.phala-cloud/credentials.json`. See [`profiles`](/phala-cloud/phala-cloud-cli/profiles) and [`switch`](/phala-cloud/phala-cloud-cli/switch).
+</Warning>
 
 ## Usage
 

--- a/phala-cloud/phala-cloud-cli/docker.mdx
+++ b/phala-cloud/phala-cloud-cli/docker.mdx
@@ -1,7 +1,11 @@
 ---
-title: "phala docker"
+title: "phala docker (Deprecated)"
 description: "Docker Hub login and image management helpers."
 ---
+
+<Warning>
+`phala docker` is deprecated. Use the standard `docker` CLI for building and pushing images.
+</Warning>
 
 ## Usage
 

--- a/phala-cloud/phala-cloud-cli/overview.mdx
+++ b/phala-cloud/phala-cloud-cli/overview.mdx
@@ -77,10 +77,30 @@ You can override the API version via:
 |---------|-------------|
 | [`api`](/phala-cloud/phala-cloud-cli/api) | Make authenticated API requests |
 | [`self`](/phala-cloud/phala-cloud-cli/self) | CLI self-management (update) |
-| [`config`](/phala-cloud/phala-cloud-cli/config) | Manage local CLI configuration |
-| [`docker`](/phala-cloud/phala-cloud-cli/docker) | Docker image build/push helpers |
 | [`simulator`](/phala-cloud/phala-cloud-cli/simulator) | Local TEE simulator for development |
 | [`completion`](/phala-cloud/phala-cloud-cli/completion) | Generate shell completion scripts |
+
+## Deprecated
+
+These commands are deprecated and will be removed in a future release.
+
+| Command | Use instead |
+|---------|-------------|
+| `auth` | [`login`](/phala-cloud/phala-cloud-cli/login), [`logout`](/phala-cloud/phala-cloud-cli/logout), [`status`](/phala-cloud/phala-cloud-cli/status) |
+| [`config`](/phala-cloud/phala-cloud-cli/config) | Profile-based credentials (`~/.phala-cloud/credentials.json`) |
+| [`docker`](/phala-cloud/phala-cloud-cli/docker) | Standard `docker` CLI for build/push |
+| `cvms create` | [`deploy`](/phala-cloud/phala-cloud-cli/deploy) |
+| `cvms upgrade` | [`deploy --cvm-id <id>`](/phala-cloud/phala-cloud-cli/deploy) |
+| `cvms logs` | [`logs`](/phala-cloud/phala-cloud-cli/logs) |
+| `cvms serial-logs` | [`logs --serial`](/phala-cloud/phala-cloud-cli/logs) |
+
+Deprecated `deploy` options:
+
+| Option | Use instead |
+|--------|-------------|
+| `--vcpu`, `--memory` | `--instance-type` |
+| `--env-file` | `-e` |
+| `--kms-id`, `--uuid` | `--custom-app-id` |
 
 ## Profiles & Credentials
 


### PR DESCRIPTION
## Summary

- Add a **Deprecated** section to the CLI overview listing all deprecated commands (`auth`, `config`, `docker`, `cvms create/upgrade/logs/serial-logs`) and deprecated `deploy` options (`--vcpu`, `--memory`, `--env-file`, `--kms-id`, `--uuid`) with their replacements
- Add `<Warning>` deprecation notices to `config.mdx` and `docker.mdx` pages
- Move `config` and `docker` from the "Advanced" nav group to a new "Deprecated" nav group in `docs.json`

## Test plan

- [ ] Verify CLI overview page renders the new Deprecated section
- [ ] Verify `config` and `docker` pages show deprecation warnings
- [ ] Verify sidebar shows the Deprecated group under Phala Cloud CLI