### PR TITLE
docs: add version markers to CLI and SDK documentation

### DIFF
--- a/phala-cloud/phala-cloud-cli/changelog.mdx
+++ b/phala-cloud/phala-cloud-cli/changelog.mdx
@@ -3,6 +3,28 @@ title: Changelog
 description: Release history for the Phala Cloud CLI
 ---
 
+## [1.1.12](https://github.com/Phala-Network/phala-cloud/compare/cli-v1.1.12-beta.1...cli-v1.1.12) (2026-03-04)
+
+### feat
+
+* **cli:** add --api-version global option ([f96397f](https://github.com/Phala-Network/phala-cloud/commit/f96397f81056af09fb854b3fc99cda09721c5e2f))
+
+### fix
+
+* **cli:** validate --api-version flag against supported versions ([a6b4f68](https://github.com/Phala-Network/phala-cloud/commit/a6b4f684039cf5e676160fcce2bc6f4084e26dee))
+
+## [1.1.12-beta.1](https://github.com/Phala-Network/phala-cloud/compare/cli-v1.1.11...cli-v1.1.12-beta.1) (2026-03-03)
+
+### feat
+
+* **cli:** show changelog URL in self update command ([8f569e8](https://github.com/Phala-Network/phala-cloud/commit/8f569e8c4361848708e2b0e06a423686d9461942))
+* **cli:** show changelog URL in update notifications ([22a6648](https://github.com/Phala-Network/phala-cloud/commit/22a6648b5f21384c4675f652bc25bcd6d0bb97e6))
+
+### fix
+
+* **cli:** use --no-cache and exact version for bun global installs ([a63a11d](https://github.com/Phala-Network/phala-cloud/commit/a63a11d19e0b6248e99acf93851c2dabec462fcc))
+* **cli:** use generic id field in waitForCvmReady poller ([4b2132d](https://github.com/Phala-Network/phala-cloud/commit/4b2132dd25ef752ada519570efcfb0c744b1cfcb))
+
 ## [1.1.11](https://github.com/Phala-Network/phala-cloud/compare/cli-v1.1.10...cli-v1.1.11) (2026-03-02)
 
 ### fix

--- a/phala-cloud/phala-cloud-cli/overview.mdx
+++ b/phala-cloud/phala-cloud-cli/overview.mdx
@@ -28,10 +28,11 @@ The CLI sends an `X-Phala-Version` header with every request. This determines th
 | `2026-01-21` | Default (current) |
 | `2025-10-28` | Legacy |
 
-You can override the API version via:
+You can override the API version with the `--api-version` global flag *(added in v1.1.12)*:
 
-- The `--api-version` global flag: `phala cvms list --api-version 2025-10-28`
-- The `api_version` field in `phala.toml`
+```bash
+phala apps --api-version 2025-10-28
+```
 
 ## Authentication
 
@@ -137,7 +138,6 @@ Project-level configuration is in `phala.toml` in the working directory. Support
 |-------|------|-------------|
 | `id` / `uuid` / `app_id` / `instance_id` / `name` | `string` | CVM identifier (any format) |
 | `profile` | `string` | Auth profile to use for this project |
-| `api_version` | `string` | API version override (e.g., `"2025-10-28"`) |
 | `gateway_domain` | `string` | Custom gateway domain |
 | `gateway_port` | `number` | Custom gateway port |
 | `compose_file` | `string` | Path to Docker Compose file |
@@ -162,7 +162,7 @@ public_logs = true
 |------|-------------|
 | `--json` | Output in JSON format for programmatic use |
 | `--api-token <token>` | Override the stored API key for this command |
-| `--api-version <version>` | Override the API version (e.g., `2025-10-28`, `2026-01-21`) |
+| `--api-version <version>` | Override the API version (e.g., `2025-10-28`, `2026-01-21`). *Added in v1.1.12* |
 
 ## Related
 

--- a/phala-cloud/references/cloud-js-sdk/cvm-configuration.mdx
+++ b/phala-cloud/references/cloud-js-sdk/cvm-configuration.mdx
@@ -112,6 +112,10 @@ images.forEach(img => console.log(img.name, img.version));
 
 ---
 
+<Note>
+`refreshCvmInstanceId` is unreleased — added after `@phala/cloud` v0.2.4. It will be available in a future release.
+</Note>
+
 ## refreshCvmInstanceId
 
 `POST /cvms/{cvmId}/refresh-instance-id`
@@ -127,6 +131,10 @@ Generates a new instance ID for a CVM. This invalidates the old instance ID.
 **Returns:** `InstanceIdRefreshResult` with the new `instance_id`.
 
 ---
+
+<Note>
+`refreshCvmInstanceIds` is unreleased — added after `@phala/cloud` v0.2.4. It will be available in a future release.
+</Note>
 
 ## refreshCvmInstanceIds
 

--- a/phala-cloud/references/cloud-js-sdk/cvm-lifecycle.mdx
+++ b/phala-cloud/references/cloud-js-sdk/cvm-lifecycle.mdx
@@ -107,6 +107,10 @@ await client.deleteCvm({ id: "my-app" });
 
 ---
 
+<Note>
+`replicateCvm` is unreleased — added after `@phala/cloud` v0.2.4. It will be available in a future release.
+</Note>
+
 ## replicateCvm
 
 `POST /cvms/{cvmId}/replicate`


### PR DESCRIPTION
## Summary

- Mark `--api-version` CLI flag as **added in v1.1.12**; remove `api_version` from `phala.toml` docs (parsed by schema but never consumed by CLI)
- Add **v1.1.12** and **v1.1.12-beta.1** entries to CLI changelog
- Mark `replicateCvm`, `refreshCvmInstanceId`, `refreshCvmInstanceIds` as **unreleased** (added after `@phala/cloud` v0.2.4)

## Test plan

- [ ] Verify `--api-version` references all carry the v1.1.12 annotation
- [ ] Verify `api_version` no longer appears in `phala.toml` docs
- [ ] Verify changelog entries match source CHANGELOG.md
- [ ] Verify `<Note>` blocks render correctly on unreleased SDK functions