### PR TITLE
fix: link validator should accept pages that exist on disk

### DIFF
--- a/.scripts/check_links.py
+++ b/.scripts/check_links.py
@@ -202,7 +202,12 @@ def main():
             if destination:
                 redirected_links.append((normalized_link, destination))
             else:
-                uncovered_links.append(normalized_link)
+                # Check if the .mdx file exists on disk (page exists but not in nav)
+                mdx_path = Path(f"{normalized_link}.mdx")
+                if mdx_path.exists():
+                    accessible_links_list.append(normalized_link)
+                else:
+                    uncovered_links.append(normalized_link)
 
     # Report results
     print(f"\n🔗 ACCESSIBLE LINKS ({len(accessible_links_list)}):")


### PR DESCRIPTION
## Summary
- Update `check_links.py` to check if a `.mdx` file exists on disk before marking a link as uncovered
- Pages removed from sidebar nav but still present on disk are valid (accessible via direct URL)

## Test plan
- [x] Verify CI passes — previously uncovered links to existing-but-unlisted pages should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)