### PR TITLE
fix: preserve docs.json key order to prevent OpenAPI embed 404s

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+fail_fast: true
+
 repos:
   # Built-in hooks for basic file validation
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -18,7 +20,9 @@ repos:
     rev: v4.4.0
     hooks:
       - id: pretty-format-json
-        args: [--autofix, --indent=2]
+        # --no-sort-keys preserves author-controlled ordering (notably the
+        # `openapi` field position); we only normalize indentation.
+        args: [--autofix, --indent=2, --no-sort-keys]
         files: ^docs\.json$
 
   # Local hooks for Mintlify-specific validation


### PR DESCRIPTION
## Summary

- Add `--no-sort-keys` to `pretty-format-json` hook so `openapi` key stays declared before `navigation` in docs.json
- Add `fail_fast: true` to stop on first hook failure
- Root cause: alphabetical sorting moves `openapi` after `navigation` (o > n), causing Mintlify to 404 embedded API pages that it encounters before finding the OpenAPI spec declaration

## Test plan

- [ ] Verify embedded API reference pages (e.g. `GET /api/v1/apps`) no longer 404 on the preview deployment
- [ ] Confirm `git commit` with docs.json changes no longer reorders keys