### PR TITLE
docs: update CLI changelog for v1.1.16

### DIFF
--- a/phala-cloud/phala-cloud-cli/changelog.mdx
+++ b/phala-cloud/phala-cloud-cli/changelog.mdx
@@ -3,6 +3,16 @@ title: Changelog
 description: Release history for the Phala Cloud CLI
 ---
 
+## [1.1.16](https://github.com/Phala-Network/phala-cloud/compare/cli-v1.1.15...cli-v1.1.16) (2026-04-10)
+
+### fix
+
+* **cli:** correct deploy --commit requirements in --help ([157f103](https://github.com/Phala-Network/phala-cloud/commit/157f103bb4033cc49abdacc6541d28db15b8a82b))
+
+### refactor
+
+* clarify --help strings and unify --transaction-hash option ([0749dc0](https://github.com/Phala-Network/phala-cloud/commit/0749dc0bc193697ef44d1ac86069d689838b9f58))
+
 ## [1.1.15](https://github.com/Phala-Network/phala-cloud/compare/cli-v1.1.14...cli-v1.1.15) (2026-04-10)
 
 ### feat

--- a/phala-cloud/phala-cloud-cli/deploy.mdx
+++ b/phala-cloud/phala-cloud-cli/deploy.mdx
@@ -19,8 +19,6 @@ Deploy new CVM or update existing one
 
 | Option | Description |
 | ------ | ----------- |
-| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
-| `-i, --interactive` | Enable interactive mode |
 | `-n, --name <value>` | CVM name (defaults to directory name) |
 | `-c, --compose <value>` | Path to Docker Compose file (default: docker-compose.yml) |
 | `-t, --instance-type <value>` | Instance type (e.g., tdx.small, auto-selected if omitted) |
@@ -34,18 +32,6 @@ Deploy new CVM or update existing one
 | `--public-sysinfo, --no-public-sysinfo` | Make CVM system info publicly accessible (default: true) |
 | `--listed, --no-listed` | List CVM on the public Trust Center (default: false) |
 
-### Multisig / Two-Phase Options
-
-For on-chain KMS (Ethereum/Base) with multisig contract owners. See [Multisig Update Flow](#multisig-update-flow).
-
-| Option | Description |
-| ------ | ----------- |
-| `--prepare-only` | Prepare the update and generate a commit token. Skips all on-chain operations. Intended for multisig workflows. |
-| `--commit` | Commit a previously prepared update using a commit token. Requires `--token`; `--compose-hash` and `--transaction-hash` are read from the token when omitted. |
-| `--token <value>` | Commit token from a prepare-only update. |
-| `--compose-hash <value>` | Compose hash from a prepare-only update. Optional when the token can provide it. |
-| `--transaction-hash <value>` | Transaction hash proving on-chain compose hash registration. Pass `already-registered` to skip the proof and rely on state-only verification. |
-
 ### Advanced Options
 
 | Option | Description |
@@ -58,8 +44,13 @@ For on-chain KMS (Ethereum/Base) with multisig contract owners. See [Multisig Up
 | `--custom-app-id <value>` | Custom App ID (requires --nonce for PHALA KMS) |
 | `--nonce <value>` | Nonce for deterministic app_id (requires --custom-app-id, PHALA KMS only) |
 | `--pre-launch-script <value>` | Path to pre-launch script |
-| `--private-key <value>` | Private key for signing on-chain transactions (or set `PRIVATE_KEY` env var) |
-| `--rpc-url <value>` | RPC URL for on-chain KMS transactions (or set `ETH_RPC_URL` env var) |
+| `--private-key <value>` | Private key for signing on-chain transactions (or set PRIVATE_KEY env var) |
+| `--rpc-url <value>` | RPC URL for on-chain KMS transactions (or set ETH_RPC_URL env var) |
+| `--prepare-only` | Prepare the update and generate a commit token. Skips all on-chain operations. Intended for multisig workflows. |
+| `--commit` | Commit a previously prepared update using a commit token. Requires --token; --compose-hash and --transaction-hash are read from the token when omitted. |
+| `--token <value>` | Commit token from a prepare-only update. |
+| `--compose-hash <value>` | Compose hash from a prepare-only update. Optional in --commit mode when the token can provide it. |
+| `--transaction-hash <value>` | Transaction hash proving on-chain compose hash registration. Pass `already-registered` to skip the proof and rely on state-only verification. |
 
 ### Deprecated Options
 
@@ -79,6 +70,9 @@ For on-chain KMS (Ethereum/Base) with multisig contract owners. See [Multisig Up
 | `-v, --version` | Show CLI version |
 | `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
 | `-j, --json, --no-json` | Output in JSON format |
+| `-i, --interactive` | Enable interactive mode |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
 ### Examples
@@ -161,42 +155,15 @@ phala deploy --listed
 phala deploy --cvm-id app_123 --no-public-logs
 ```
 
-### Multisig Update Flow
-
-When the on-chain KMS contract owner is a multisig wallet, the CLI cannot complete the on-chain transaction in a single operation. Use the two-phase flow:
-
-* **Phase 1**: Prepare the update (generate commit token)
+* Prepare update for multisig approval
 
 ```bash
-phala deploy --cvm-id app_abc123 --prepare-only -c docker-compose.yml -e .env
+phala deploy --cvm-id app_123 --prepare-only -c docker-compose.yml
 ```
 
-This outputs the compose hash, on-chain status, and a commit token. The token is valid for 14 days.
-
-* **Phase 2**: After multisig approval and on-chain registration, commit the update
+* Commit a prepared update
 
 ```bash
-phala deploy --cvm-id app_abc123 \
-  --commit \
-  --token <commit-token>
+phala deploy --cvm-id app_123 --commit --token <token> --compose-hash 0x... --transaction-hash 0x...
 ```
-
-If the compose hash is already registered on-chain, `--transaction-hash` can be omitted (defaults to state-only check).
-
-* With explicit transaction hash
-
-```bash
-phala deploy --cvm-id app_abc123 \
-  --commit \
-  --token <commit-token> \
-  --transaction-hash 0x...
-```
-
-* You can also commit via the API directly
-
-```bash
-curl -X POST 'https://cloud-api.phala.com/api/v1/cvms/<uuid>/commit-update?token=<commit-token>'
-```
-
-Or use the **Confirm Update** page in the dashboard (link provided in `--prepare-only` output).
 


### PR DESCRIPTION
## Changes

- CLI v1.1.16
  - fix: correct deploy --commit requirements in --help
  - refactor: clarify --help strings and unify --transaction-hash option

JS SDK remains at v0.2.7 (no new release).