### PR TITLE
docs: fix CLI docs generator and OpenAPI reference rendering

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -215,7 +215,13 @@
                     "pages": [
                       "/phala-cloud/phala-cloud-cli/deploy",
                       "/phala-cloud/phala-cloud-cli/instance-types",
-                      "/phala-cloud/phala-cloud-cli/nodes",
+                      {
+                        "group": "nodes",
+                        "pages": [
+                          "/phala-cloud/phala-cloud-cli/nodes",
+                          "/phala-cloud/phala-cloud-cli/nodes/list"
+                        ]
+                      },
                       "/phala-cloud/phala-cloud-cli/os-images"
                     ]
                   },
@@ -223,11 +229,63 @@
                     "group": "Manage",
                     "pages": [
                       "/phala-cloud/phala-cloud-cli/apps",
-                      "/phala-cloud/phala-cloud-cli/cvms",
-                      "/phala-cloud/phala-cloud-cli/envs",
+                      {
+                        "group": "instances",
+                        "pages": [
+                          "/phala-cloud/phala-cloud-cli/instances",
+                          "/phala-cloud/phala-cloud-cli/instances/ls",
+                          "/phala-cloud/phala-cloud-cli/instances/add",
+                          "/phala-cloud/phala-cloud-cli/instances/rm"
+                        ]
+                      },
+                      {
+                        "group": "cvms",
+                        "pages": [
+                          "/phala-cloud/phala-cloud-cli/cvms",
+                          "/phala-cloud/phala-cloud-cli/cvms/attestation",
+                          "/phala-cloud/phala-cloud-cli/cvms/create",
+                          "/phala-cloud/phala-cloud-cli/cvms/delete",
+                          "/phala-cloud/phala-cloud-cli/cvms/device-allowlist",
+                          "/phala-cloud/phala-cloud-cli/cvms/get",
+                          "/phala-cloud/phala-cloud-cli/cvms/list",
+                          "/phala-cloud/phala-cloud-cli/cvms/list-nodes",
+                          "/phala-cloud/phala-cloud-cli/cvms/logs",
+                          "/phala-cloud/phala-cloud-cli/cvms/replicate",
+                          "/phala-cloud/phala-cloud-cli/cvms/resize",
+                          "/phala-cloud/phala-cloud-cli/cvms/restart",
+                          "/phala-cloud/phala-cloud-cli/cvms/serial-logs",
+                          "/phala-cloud/phala-cloud-cli/cvms/start",
+                          "/phala-cloud/phala-cloud-cli/cvms/stop",
+                          "/phala-cloud/phala-cloud-cli/cvms/upgrade"
+                        ]
+                      },
+                      {
+                        "group": "envs",
+                        "pages": [
+                          "/phala-cloud/phala-cloud-cli/envs",
+                          "/phala-cloud/phala-cloud-cli/envs/encrypt",
+                          "/phala-cloud/phala-cloud-cli/envs/update"
+                        ]
+                      },
                       "/phala-cloud/phala-cloud-cli/link",
-                      "/phala-cloud/phala-cloud-cli/simulator",
-                      "/phala-cloud/phala-cloud-cli/ssh-keys"
+                      {
+                        "group": "simulator",
+                        "pages": [
+                          "/phala-cloud/phala-cloud-cli/simulator",
+                          "/phala-cloud/phala-cloud-cli/simulator/start",
+                          "/phala-cloud/phala-cloud-cli/simulator/stop"
+                        ]
+                      },
+                      {
+                        "group": "ssh-keys",
+                        "pages": [
+                          "/phala-cloud/phala-cloud-cli/ssh-keys",
+                          "/phala-cloud/phala-cloud-cli/ssh-keys/list",
+                          "/phala-cloud/phala-cloud-cli/ssh-keys/add",
+                          "/phala-cloud/phala-cloud-cli/ssh-keys/remove",
+                          "/phala-cloud/phala-cloud-cli/ssh-keys/import-github"
+                        ]
+                      }
                     ]
                   },
                   {
@@ -245,7 +303,15 @@
                     "pages": [
                       "/phala-cloud/phala-cloud-cli/login",
                       "/phala-cloud/phala-cloud-cli/logout",
-                      "/phala-cloud/phala-cloud-cli/profiles",
+                      {
+                        "group": "profiles",
+                        "pages": [
+                          "/phala-cloud/phala-cloud-cli/profiles",
+                          "/phala-cloud/phala-cloud-cli/profiles/use",
+                          "/phala-cloud/phala-cloud-cli/profiles/rename",
+                          "/phala-cloud/phala-cloud-cli/profiles/delete"
+                        ]
+                      },
                       "/phala-cloud/phala-cloud-cli/status",
                       "/phala-cloud/phala-cloud-cli/switch",
                       "/phala-cloud/phala-cloud-cli/whoami"
@@ -254,19 +320,70 @@
                   {
                     "group": "Advanced",
                     "pages": [
-                      "/phala-cloud/phala-cloud-cli/allow-devices",
+                      {
+                        "group": "allow-devices",
+                        "pages": [
+                          "/phala-cloud/phala-cloud-cli/allow-devices",
+                          "/phala-cloud/phala-cloud-cli/allow-devices/list",
+                          "/phala-cloud/phala-cloud-cli/allow-devices/add",
+                          "/phala-cloud/phala-cloud-cli/allow-devices/remove",
+                          "/phala-cloud/phala-cloud-cli/allow-devices/allow-any",
+                          "/phala-cloud/phala-cloud-cli/allow-devices/disallow-any",
+                          "/phala-cloud/phala-cloud-cli/allow-devices/toggle-allow-any"
+                        ]
+                      },
                       "/phala-cloud/phala-cloud-cli/api",
                       "/phala-cloud/phala-cloud-cli/completion",
-                      "/phala-cloud/phala-cloud-cli/kms",
-                      "/phala-cloud/phala-cloud-cli/self"
+                      {
+                        "group": "kms",
+                        "pages": [
+                          "/phala-cloud/phala-cloud-cli/kms",
+                          "/phala-cloud/phala-cloud-cli/kms/list",
+                          "/phala-cloud/phala-cloud-cli/kms/ethereum",
+                          "/phala-cloud/phala-cloud-cli/kms/base"
+                        ]
+                      },
+                      {
+                        "group": "self",
+                        "pages": [
+                          "/phala-cloud/phala-cloud-cli/self",
+                          "/phala-cloud/phala-cloud-cli/self/update"
+                        ]
+                      }
                     ]
                   },
                   {
                     "group": "Deprecated",
                     "pages": [
-                      "/phala-cloud/phala-cloud-cli/auth",
-                      "/phala-cloud/phala-cloud-cli/config",
-                      "/phala-cloud/phala-cloud-cli/docker"
+                      {
+                        "group": "auth",
+                        "pages": [
+                          "/phala-cloud/phala-cloud-cli/auth",
+                          "/phala-cloud/phala-cloud-cli/auth/login",
+                          "/phala-cloud/phala-cloud-cli/auth/logout",
+                          "/phala-cloud/phala-cloud-cli/auth/status"
+                        ]
+                      },
+                      {
+                        "group": "config",
+                        "pages": [
+                          "/phala-cloud/phala-cloud-cli/config",
+                          "/phala-cloud/phala-cloud-cli/config/get",
+                          "/phala-cloud/phala-cloud-cli/config/list",
+                          "/phala-cloud/phala-cloud-cli/config/set"
+                        ]
+                      },
+                      {
+                        "group": "docker",
+                        "pages": [
+                          "/phala-cloud/phala-cloud-cli/docker",
+                          "/phala-cloud/phala-cloud-cli/docker/login",
+                          "/phala-cloud/phala-cloud-cli/docker/build",
+                          "/phala-cloud/phala-cloud-cli/docker/push",
+                          "/phala-cloud/phala-cloud-cli/docker/generate",
+                          "/phala-cloud/phala-cloud-cli/docker/run"
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/docs.json
+++ b/docs.json
@@ -514,6 +514,7 @@
                   "/phala-cloud/references/overview",
                   {
                     "group": "Phala Cloud API",
+                    "openapi": "openapi.json",
                     "pages": [
                       "/phala-cloud/phala-cloud-api/overview",
                       "/phala-cloud/phala-cloud-api/attestations",
@@ -525,12 +526,16 @@
                           "GET /api/v1/apps/filter-options",
                           "GET /api/v1/apps/{app_id}",
                           "GET /api/v1/apps/{app_id}/attestations",
+                          "GET /api/v1/apps/{app_id}/attestations/tcb-evaluation",
                           "GET /api/v1/apps/{app_id}/cvms",
                           "POST /api/v1/apps/{app_id}/cvms/is-allowed",
                           "POST /api/v1/apps/{app_id}/cvms/{vm_uuid}/replicas",
+                          "POST /api/v1/apps/{app_id}/instances",
                           "GET /api/v1/apps/{app_id}/device-allowlist",
-                          "GET /api/v1/apps/{app_id}/events",
                           "POST /api/v1/apps/{app_id}/is-allowed",
+                          "GET /api/v1/apps/{app_id}/kms-info",
+                          "GET /api/v1/apps/{app_id}/pending-updates",
+                          "GET /api/v1/apps/{app_id}/pending-updates/{vm_uuid}/{compose_hash}/preview",
                           "GET /api/v1/apps/{app_id}/revisions",
                           "GET /api/v1/apps/{app_id}/revisions/{revision_id}",
                           "POST /api/v1/apps/{app_id}/revisions/{revision_id}/redeploy",
@@ -548,8 +553,6 @@
                           "POST /api/v1/cvms/batch-stop",
                           "POST /api/v1/cvms/eliza",
                           "POST /api/v1/cvms/provision/eliza",
-                          "POST /api/v1/cvms/from_cvm_configuration",
-                          "POST /api/v1/cvms/pubkey/from_cvm_configuration",
                           "PATCH /api/v1/cvms/instance-ids",
                           "POST /api/v1/status/batch",
                           "GET /api/v1/cvms/{cvm_id}",
@@ -557,31 +560,33 @@
                           "PATCH /api/v1/cvms/{cvm_id}",
                           "GET /api/v1/cvms/{cvm_id}/attestation",
                           "GET /api/v1/cvms/{cvm_id}/available-os-images",
+                          "POST /api/v1/cvms/{cvm_id}/commit-replica",
                           "GET /api/v1/cvms/{cvm_id}/commit-update",
                           "POST /api/v1/cvms/{cvm_id}/commit-update",
-                          "GET /api/v1/cvms/{cvm_id}/compose",
-                          "PUT /api/v1/cvms/{cvm_id}/compose",
-                          "PATCH /api/v1/cvms/{cvm_id}/compose",
                           "GET /api/v1/cvms/{cvm_id}/compose_file",
                           "PATCH /api/v1/cvms/{cvm_id}/compose_file",
                           "POST /api/v1/cvms/{cvm_id}/compose_file",
                           "POST /api/v1/cvms/{cvm_id}/compose_file/provision",
-                          "GET /api/v1/cvms/{cvm_id}/composition",
                           "POST /api/v1/cvms/{cvm_id}/customize-domain-diagnose",
                           "PATCH /api/v1/cvms/{cvm_id}/docker-compose",
                           "GET /api/v1/cvms/{cvm_id}/docker-compose.yml",
                           "PATCH /api/v1/cvms/{cvm_id}/envs",
+                          "GET /api/v1/cvms/{cvm_id}/firewall-status",
                           "PATCH /api/v1/cvms/{cvm_id}/instance-id",
                           "PATCH /api/v1/cvms/{cvm_id}/listed",
                           "PATCH /api/v1/cvms/{cvm_id}/name",
                           "GET /api/v1/cvms/{cvm_id}/network",
+                          "GET /api/v1/cvms/{cvm_id}/network-config",
+                          "PATCH /api/v1/cvms/{cvm_id}/network-config",
                           "GET /api/v1/cvms/{cvm_id}/operation-status",
                           "GET /api/v1/cvms/{cvm_id}/operations",
+                          "POST /api/v1/cvms/{cvm_id}/operations/cancel",
                           "PATCH /api/v1/cvms/{cvm_id}/os-image",
+                          "GET /api/v1/cvms/{cvm_id}/ports",
+                          "PUT /api/v1/cvms/{cvm_id}/ports",
                           "GET /api/v1/cvms/{cvm_id}/pre-launch-script",
                           "PATCH /api/v1/cvms/{cvm_id}/pre-launch-script",
                           "POST /api/v1/cvms/{cvm_id}/replicas",
-                          "PATCH /api/v1/cvms/{cvm_id}/resources",
                           "POST /api/v1/cvms/{cvm_id}/restart",
                           "POST /api/v1/cvms/{cvm_id}/revisions/{revision_id}/redeploy",
                           "PATCH /api/v1/cvms/{cvm_id}/scheduled-delete",
@@ -590,8 +595,7 @@
                           "GET /api/v1/cvms/{cvm_id}/state",
                           "GET /api/v1/cvms/{cvm_id}/stats",
                           "POST /api/v1/cvms/{cvm_id}/stop",
-                          "GET /api/v1/cvms/{cvm_id}/user_config",
-                          "PATCH /api/v1/cvms/{cvm_id}/visibility"
+                          "GET /api/v1/cvms/{cvm_id}/user_config"
                         ]
                       },
                       {
@@ -606,52 +610,6 @@
                           "GET /api/v1/attestations/nodes",
                           "GET /api/v1/attestations/device_ids",
                           "GET /api/v1/attestations/ppids"
-                        ]
-                      },
-                      {
-                        "group": "Authentication",
-                        "pages": [
-                          "POST /api/v1/auth/token",
-                          "GET /api/v1/auth/authenticated",
-                          "GET /api/v1/auth/me",
-                          "POST /api/v1/auth/login",
-                          "POST /api/v1/auth/logout",
-                          "POST /api/v1/auth/register",
-                          "POST /api/v1/auth/forgot-password",
-                          "PUT /api/v1/auth/reset-password",
-                          "GET /api/v1/auth/validate-reset-token",
-                          "POST /api/v1/auth/password",
-                          "POST /api/v1/auth/change-email",
-                          "POST /api/v1/auth/request-email-verification",
-                          "POST /api/v1/auth/verify-email-token",
-                          "PUT /api/v1/auth/username",
-                          "GET /api/v1/auth/sessions",
-                          "DELETE /api/v1/auth/sessions",
-                          "DELETE /api/v1/auth/sessions/{jti}",
-                          "POST /api/v1/auth/step-up/verify",
-                          "GET /api/v1/auth/oauth/google/authorize",
-                          "GET /api/v1/auth/oauth/google/callback",
-                          "GET /api/v1/auth/oauth/github/authorize",
-                          "GET /api/v1/auth/oauth/github/callback",
-                          "GET /api/v1/auth/decode-link-token",
-                          "POST /api/v1/auth/verify-and-link-oauth",
-                          "POST /api/v1/auth/login-with-2fa",
-                          "POST /api/v1/auth/2fa/setup",
-                          "POST /api/v1/auth/2fa/confirm",
-                          "POST /api/v1/auth/2fa/disable",
-                          "GET /api/v1/auth/2fa/status",
-                          "POST /api/v1/auth/2fa/verify",
-                          "POST /api/v1/auth/2fa/verify-and-set-cookie",
-                          "POST /api/v1/auth/2fa/regenerate-backup-codes"
-                        ]
-                      },
-                      {
-                        "group": "Tokens",
-                        "pages": [
-                          "GET /api/v1/tokens",
-                          "POST /api/v1/tokens",
-                          "DELETE /api/v1/tokens/{token_id}",
-                          "POST /api/v1/tokens/{token_id}/refresh"
                         ]
                       },
                       {
@@ -683,77 +641,19 @@
                         ]
                       },
                       {
-                        "group": "GPUs",
+                        "group": "Webhooks",
                         "pages": [
-                          "GET /api/v1/gpus/reserved",
-                          "POST /api/v1/gpus/switch-mode"
-                        ]
-                      },
-                      {
-                        "group": "Workspace",
-                        "pages": [
-                          "GET /api/v1/workspaces",
-                          "POST /api/v1/workspaces/check-slug",
-                          "GET /api/v1/workspaces/{team_slug}",
-                          "GET /api/v1/workspaces/{team_slug}/nodes",
-                          "GET /api/v1/workspaces/{team_slug}/quotas",
-                          "POST /api/v1/workspaces/{workspace_slug}/invitations",
-                          "GET /api/v1/workspaces/{workspace_slug}/invitations",
-                          "POST /api/v1/workspaces/{workspace_slug}/invitations/shareable",
-                          "DELETE /api/v1/workspaces/{workspace_slug}/invitations/{invitation_id}",
-                          "POST /api/v1/workspaces/{workspace_slug}/leave",
-                          "GET /api/v1/workspaces/{workspace_slug}/members",
-                          "DELETE /api/v1/workspaces/{workspace_slug}/members/{user_id}",
-                          "PATCH /api/v1/workspaces/{workspace_slug}/members/{user_id}"
-                        ]
-                      },
-                      {
-                        "group": "Billing",
-                        "pages": [
-                          "GET /api/v1/billing",
-                          "GET /api/v1/billing/balance",
-                          "GET /api/v1/billing/billing_items",
-                          "GET /api/v1/billing/billing_items/{cvm_id}",
-                          "GET /api/v1/billing/settings",
-                          "PATCH /api/v1/billing/settings",
-                          "GET /api/v1/billing/invoices",
-                          "GET /api/v1/billing/invoices/{invoice_id}",
-                          "GET /api/v1/billing/invoices/{invoice_id}/items",
-                          "POST /api/v1/billing/invoices/{invoice_id}/pay",
-                          "GET /api/v1/credits",
-                          "POST /api/v1/credits/redeem",
-                          "GET /api/v1/credits/transactions",
-                          "GET /api/v1/card",
-                          "DELETE /api/v1/card/{payment_method_id}",
-                          "POST /api/v1/charge",
-                          "GET /api/v1/debt",
-                          "POST /api/v1/debt/settlement",
-                          "GET /api/v1/orders",
-                          "POST /api/v1/setup-billing/create-intent",
-                          "POST /api/v1/setup-billing/save-intent",
-                          "GET /api/v1/setup-billing/check"
-                        ]
-                      },
-                      {
-                        "group": "Profiles",
-                        "pages": [
-                          "GET /api/v1/profiles/me",
-                          "PUT /api/v1/profiles/me",
-                          "PUT /api/v1/profiles/me/avatar",
-                          "DELETE /api/v1/profiles/me/avatar",
-                          "GET /api/v1/profiles/{entity_type}/{entity_id}",
-                          "PUT /api/v1/profiles/{entity_type}/{entity_id}",
-                          "DELETE /api/v1/profiles/{entity_type}/{entity_id}",
-                          "PUT /api/v1/profiles/{entity_type}/{entity_id}/avatar",
-                          "DELETE /api/v1/profiles/{entity_type}/{entity_id}/avatar"
-                        ]
-                      },
-                      {
-                        "group": "Usage",
-                        "pages": [
-                          "GET /api/v1/usage/current",
-                          "GET /api/v1/usage/data",
-                          "GET /api/v1/usage/export"
+                          "GET /api/v1/workspace/webhooks",
+                          "POST /api/v1/workspace/webhooks",
+                          "GET /api/v1/workspace/webhooks/{webhook_id}",
+                          "PUT /api/v1/workspace/webhooks/{webhook_id}",
+                          "DELETE /api/v1/workspace/webhooks/{webhook_id}",
+                          "POST /api/v1/workspace/webhooks/{webhook_id}/reveal-secret",
+                          "POST /api/v1/workspace/webhooks/{webhook_id}/rotate-secret",
+                          "POST /api/v1/workspace/webhooks/{webhook_id}/test",
+                          "GET /api/v1/workspace/webhooks/{webhook_id}/deliveries",
+                          "POST /api/v1/workspace/webhooks/{webhook_id}/deliveries/{event_id}/resend",
+                          "GET /api/v1/workspace/webhooks/{webhook_id}/stats"
                         ]
                       }
                     ]
@@ -907,7 +807,6 @@
       }
     ]
   },
-  "openapi": "openapi.json",
   "redirects": [
     {
       "destination": "/phala-cloud/key-management/deploying-with-onchain-kms",

--- a/openapi.json
+++ b/openapi.json
@@ -4,1911 +4,19 @@
     "title": "Phala Cloud API",
     "version": "0.1.0"
   },
+  "servers": [
+    {
+      "url": "https://cloud-api.phala.com"
+    }
+  ],
   "paths": {
-    "/api/v1/auth/oauth/google/authorize": {
-      "get": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Start Google OAuth",
-        "description": "Redirects user to Google authorization page. Supports login, registration, and account linking modes.",
-        "operationId": "google_oauth_authorize_api_v1_auth_oauth_google_authorize_get",
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "returnUrl",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Returnurl"
-            }
-          },
-          {
-            "name": "invite",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Invite"
-            }
-          },
-          {
-            "name": "mode",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Mode"
-            }
-          },
-          {
-            "name": "site_key",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Site Key"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "307": {
-            "description": "Redirect to Google authorization URL"
-          },
-          "501": {
-            "description": "Google OAuth not configured on server"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/auth/oauth/google/callback": {
-      "get": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Handle Google OAuth callback",
-        "description": "Processes Google authorization response. Creates session cookie on success or redirects with error parameter on failure.",
-        "operationId": "google_oauth_callback_api_v1_auth_oauth_google_callback_get",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Code"
-            }
-          },
-          {
-            "name": "state",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "State"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "307": {
-            "description": "Redirect to dashboard on success, login/register/settings page on error"
-          },
-          "400": {
-            "description": "Invalid state parameter or token exchange failed"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/auth/oauth/github/authorize": {
-      "get": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Start GitHub OAuth",
-        "description": "Redirects user to GitHub authorization page. Supports login, registration, and account linking modes.",
-        "operationId": "github_oauth_authorize_api_v1_auth_oauth_github_authorize_get",
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "returnUrl",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Returnurl"
-            }
-          },
-          {
-            "name": "invite",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Invite"
-            }
-          },
-          {
-            "name": "mode",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Mode"
-            }
-          },
-          {
-            "name": "site_key",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Site Key"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "307": {
-            "description": "Redirect to GitHub authorization URL"
-          },
-          "501": {
-            "description": "GitHub OAuth not configured on server"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/auth/oauth/github/callback": {
-      "get": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Handle GitHub OAuth callback",
-        "description": "Processes GitHub authorization response. Creates session cookie on success or redirects with error parameter on failure.",
-        "operationId": "github_oauth_callback_api_v1_auth_oauth_github_callback_get",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Code"
-            }
-          },
-          {
-            "name": "state",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "State"
-            }
-          },
-          {
-            "name": "error",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Error"
-            }
-          },
-          {
-            "name": "error_description",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Error Description"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "307": {
-            "description": "Redirect to dashboard on success, login/register/settings page on error"
-          },
-          "400": {
-            "description": "Invalid state parameter or token exchange failed"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/auth/me": {
-      "get": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Get current user",
-        "description": "Return detailed info for the authenticated user including workspace and credits.",
-        "operationId": "read_users_me_api_v1_auth_me_get",
-        "responses": {
-          "200": {
-            "description": "User profile with workspace and credits",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "403": {
-            "description": "User is disabled"
-          }
-        },
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ]
-      }
-    },
-    "/api/v1/auth/authenticated": {
-      "get": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Check authentication",
-        "description": "Return authentication status and user info if authenticated.",
-        "operationId": "authenticated_api_v1_auth_authenticated_get",
-        "responses": {
-          "200": {
-            "description": "Authentication status with user info if authenticated",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ]
-      }
-    },
-    "/api/v1/auth/register": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Register new user",
-        "description": "Create a new account with email verification. Requires invite code if configured.",
-        "operationId": "register_user_api_v1_auth_register_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RegisterPayload"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "User created or verification email sent",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid input, email already exists, or rate limited"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/auth/token": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Get access token",
-        "description": "OAuth2 password grant. Returns JWT token. Pass TOTP code in client_id field if 2FA enabled.",
-        "operationId": "login_for_access_token_api_v1_auth_token_post",
-        "requestBody": {
-          "content": {
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_login_for_access_token_api_v1_auth_token_post"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Access token issued",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "401": {
-            "description": "Invalid credentials, email not verified, or invalid 2FA"
-          },
-          "500": {
-            "description": "Internal authentication error"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/auth/login": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Login with cookie",
-        "description": "Authenticate and set session cookie. Pass TOTP code in client_id field if 2FA enabled.",
-        "operationId": "login_with_cookie_api_v1_auth_login_post",
-        "requestBody": {
-          "content": {
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_login_with_cookie_api_v1_auth_login_post"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Login successful, cookie set",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "401": {
-            "description": "Invalid credentials or email not verified"
-          },
-          "500": {
-            "description": "Session creation failed"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/auth/login-with-2fa": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Login with explicit 2FA",
-        "description": "Authenticate with explicit TOTP code field. Preferred over /login for 2FA users.",
-        "operationId": "login_with_2fa_api_v1_auth_login_with_2fa_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/LoginRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Login successful, cookie set",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "401": {
-            "description": "Invalid credentials or email not verified"
-          },
-          "500": {
-            "description": "Session creation failed"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/auth/logout": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Logout",
-        "description": "Revoke the current session and clear authentication cookies.",
-        "operationId": "logout_api_v1_auth_logout_post",
-        "responses": {
-          "200": {
-            "description": "Logged out successfully",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ]
-      }
-    },
-    "/api/v1/auth/forgot-password": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Request password reset",
-        "description": "Send password reset email if account exists. Response is identical whether account exists or not.",
-        "operationId": "forgot_password_api_v1_auth_forgot_password_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PasswordResetRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Reset email sent (if account exists)",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/auth/validate-reset-token": {
-      "get": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Validate reset token",
-        "description": "Check if a password reset token is valid and not expired.",
-        "operationId": "validate_reset_token_api_v1_auth_validate_reset_token_get",
-        "parameters": [
-          {
-            "name": "token",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Token"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Token is valid",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Validate Reset Token Api V1 Auth Validate Reset Token Get"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid or expired token"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/auth/reset-password": {
-      "put": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Reset password with token",
-        "description": "Set a new password using the reset token from email.",
-        "operationId": "handle_reset_password_with_token_api_v1_auth_reset_password_put",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ResetPasswordWithToken"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Password reset successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": true,
-                  "type": "object",
-                  "title": "Response Handle Reset Password With Token Api V1 Auth Reset Password Put"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid token, expired, or weak password"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/auth/password": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Update password",
-        "description": "Change password. Requires TOTP code (if 2FA enabled) or current password. Sends notification email.",
-        "operationId": "handle_update_password_api_v1_auth_password_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdatePasswordRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Password updated",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/User"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "TOTP code required or invalid, or password validation failed"
-          },
-          "401": {
-            "description": "Not authenticated or current password incorrect"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ]
-      }
-    },
-    "/api/v1/auth/username": {
-      "put": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Update username",
-        "description": "Change username. Requires TOTP code (if 2FA enabled) or current password. Revokes all other sessions.",
-        "operationId": "handle_update_username_api_v1_auth_username_put",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateUsernameRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Username updated",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "400": {
-            "description": "TOTP required, invalid TOTP, or username validation failed"
-          },
-          "401": {
-            "description": "Not authenticated or current password incorrect"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ]
-      }
-    },
-    "/api/v1/auth/request-email-verification": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Request email verification",
-        "description": "Send or resend verification email. Can also be used to change email address.",
-        "operationId": "api_request_email_verification_api_v1_auth_request_email_verification_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WrappedEmailVerificationRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Verification email sent",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "400": {
-            "description": "No email provided or send failed"
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ]
-      }
-    },
-    "/api/v1/auth/change-email": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Change email address",
-        "description": "Initiate email change. Requires verification (password or 2FA). Sends verification to new address.",
-        "operationId": "api_change_email_api_v1_auth_change_email_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WrappedChangeEmailRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Verification email sent to new address",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "400": {
-            "description": "Email send failed or invalid"
-          },
-          "401": {
-            "description": "Not authenticated or verification failed"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ]
-      }
-    },
-    "/api/v1/auth/verify-email-token": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Verify email token",
-        "description": "Complete email verification using token from email link.",
-        "operationId": "api_verify_email_token_api_v1_auth_verify_email_token_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_api_verify_email_token_api_v1_auth_verify_email_token_post"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Email verified",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": {
-                    "type": "string"
-                  },
-                  "type": "object",
-                  "title": "Response Api Verify Email Token Api V1 Auth Verify Email Token Post"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid token, expired, or site key invalid"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/auth/2fa/status": {
-      "get": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Get 2FA status",
-        "description": "Return 2FA configuration status including enabled flag and backup codes count.",
-        "operationId": "get_2fa_status_endpoint_api_v1_auth_2fa_status_get",
-        "responses": {
-          "200": {
-            "description": "2FA status",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "400": {
-            "description": "Status check failed"
-          },
-          "401": {
-            "description": "Not authenticated"
-          }
-        },
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ]
-      }
-    },
-    "/api/v1/auth/2fa/setup": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Initialize 2FA setup",
-        "description": "Generate TOTP secret and QR code. Secret is only shown once. Call /2fa/confirm to activate.",
-        "operationId": "setup_2fa_endpoint_api_v1_auth_2fa_setup_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_setup_2fa_endpoint_api_v1_auth_2fa_setup_post"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Secret and QR code for authenticator app",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "400": {
-            "description": "2FA already enabled"
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ]
-      }
-    },
-    "/api/v1/auth/2fa/confirm": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Confirm 2FA setup",
-        "description": "Activate 2FA by verifying a TOTP code from authenticator app. Returns backup codes.",
-        "operationId": "confirm_2fa_setup_endpoint_api_v1_auth_2fa_confirm_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TwoFactorSetupRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "2FA enabled with backup codes",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid code or no pending setup"
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ]
-      }
-    },
-    "/api/v1/auth/2fa/disable": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Disable 2FA",
-        "description": "Turn off 2FA. Requires valid TOTP code or backup code.",
-        "operationId": "disable_2fa_endpoint_api_v1_auth_2fa_disable_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TwoFactorDisableRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "2FA disabled",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid verification code"
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ]
-      }
-    },
-    "/api/v1/auth/2fa/regenerate-backup-codes": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Regenerate backup codes",
-        "description": "Generate new backup codes. Invalidates previous codes. Requires valid TOTP code.",
-        "operationId": "regenerate_backup_codes_endpoint_api_v1_auth_2fa_regenerate_backup_codes_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TwoFactorRegenerateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "New backup codes",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid verification code or 2FA not enabled"
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ]
-      }
-    },
-    "/api/v1/auth/2fa/verify": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Verify 2FA code",
-        "description": "Verify a TOTP or backup code. Sets step-up cookie on success.",
-        "operationId": "verify_2fa_endpoint_api_v1_auth_2fa_verify_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TwoFactorVerificationRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Code valid, step-up cookie set",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid code"
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ]
-      }
-    },
-    "/api/v1/auth/2fa/verify-and-set-cookie": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Verify 2FA and set cookie",
-        "description": "Verify TOTP code and set step-up cookie for subsequent sensitive operations.",
-        "operationId": "verify_2fa_and_set_cookie_api_v1_auth_2fa_verify_and_set_cookie_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TwoFactorPageVerifyRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "2FA verified, step-up cookie set",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid code"
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ]
-      }
-    },
-    "/api/v1/auth/step-up/verify": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Step-up verification",
-        "description": "Verify password or TOTP to get step-up cookie. Required for sensitive operations.",
-        "operationId": "verify_step_up_and_set_cookie_api_v1_auth_step_up_verify_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/StepUpVerifyRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Verification passed, step-up cookie set",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "400": {
-            "description": "Neither password nor TOTP provided, or code invalid"
-          },
-          "401": {
-            "description": "Not authenticated or password incorrect"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ]
-      }
-    },
-    "/api/v1/auth/sessions": {
-      "get": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "List active sessions",
-        "description": "Return all active sessions for the current user with device info.",
-        "operationId": "get_active_sessions_api_v1_auth_sessions_get",
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "site_key",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Site Key"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "List of sessions",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SessionsListResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "500": {
-            "description": "Session query failed"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Revoke all sessions",
-        "description": "Revoke all sessions. By default keeps current session. Requires 2FA step-up.",
-        "operationId": "revoke_all_sessions_api_v1_auth_sessions_delete",
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "site_key",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Site Key"
-            }
-          },
-          {
-            "name": "revoke_current",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Revoke Current"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Sessions revoked",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "428": {
-            "description": "2FA step-up required"
-          },
-          "500": {
-            "description": "Revocation failed"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/auth/sessions/{jti}": {
-      "delete": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Revoke session",
-        "description": "Revoke a specific session by JTI. Requires 2FA step-up verification.",
-        "operationId": "revoke_session_endpoint_api_v1_auth_sessions__jti__delete",
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "jti",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Jti"
-            }
-          },
-          {
-            "name": "site_key",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Site Key"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Session revoked",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "404": {
-            "description": "Session not found"
-          },
-          "428": {
-            "description": "2FA step-up required"
-          },
-          "500": {
-            "description": "Revocation failed"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/auth/decode-link-token": {
-      "get": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Decode OAuth link token",
-        "description": "Extract provider and email from OAuth link token for UI display.",
-        "operationId": "decode_link_token_api_v1_auth_decode_link_token_get",
-        "parameters": [
-          {
-            "name": "token",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Token"
-            }
-          },
-          {
-            "name": "site_key",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Site Key"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Token data (provider, email, name, avatar_url)",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid or expired token"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/auth/verify-and-link-oauth": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Link OAuth account",
-        "description": "Verify password/2FA and link OAuth account. Used when OAuth email matches existing user.",
-        "operationId": "verify_and_link_oauth_api_v1_auth_verify_and_link_oauth_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/VerifyAndLinkOAuthRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Account linked and logged in, or requires_2fa flag",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid token, password required, or link failed"
-          },
-          "401": {
-            "description": "Invalid password or 2FA code"
-          },
-          "404": {
-            "description": "User not found"
-          },
-          "423": {
-            "description": "Account is disabled"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/cvms/pubkey/from_cvm_configuration": {
-      "post": {
-        "tags": [
-          "CVMs"
-        ],
-        "summary": "Get pubkey from config (legacy)",
-        "description": "Deprecated. Returns app_id and encryption pubkey from VM configuration.",
-        "operationId": "handle_get_pubkey_from_cvm_configuration_api_v1_cvms_pubkey_from_cvm_configuration_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/VMCreateWithTeepod",
-                "description": "The Compose Manifest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "deprecated": true,
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ]
-      }
-    },
-    "/api/v1/cvms/from_cvm_configuration": {
-      "post": {
-        "tags": [
-          "CVMs"
-        ],
-        "summary": "Create CVM from config (legacy)",
-        "description": "Deprecated. Creates CVM from raw VM configuration payload.",
-        "operationId": "handle_create_cvm_with_vm_config_api_v1_cvms_from_cvm_configuration_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/VMCreateWithTeepod",
-                "description": "The Compose Manifest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VM"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "deprecated": true,
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ]
-      }
-    },
     "/api/v1/cvms/provision/eliza": {
       "post": {
         "tags": [
           "CVMs"
         ],
         "summary": "Provision Eliza app",
-        "description": "Validates Eliza configuration and caches it for 7 days. Returns compose_hash and KMS info for on-chain registration.",
+        "description": "Validates Eliza configuration and caches it for 14 days. Returns compose_hash and KMS info for on-chain registration.",
         "operationId": "handle_provision_cvm_for_eliza_api_v1_cvms_provision_eliza_post",
         "requestBody": {
           "content": {
@@ -1954,7 +62,7 @@
           "CVMs"
         ],
         "summary": "Provision DStack app",
-        "description": "Validates Docker Compose configuration and caches it for 7 days. Returns compose_hash and KMS info for on-chain registration before creation.",
+        "description": "Validates Docker Compose configuration and caches it for 14 days. Returns compose_hash and KMS info for on-chain registration before creation.",
         "operationId": "handle_provision_cvm_api_v1_cvms_provision_post",
         "requestBody": {
           "content": {
@@ -2429,7 +537,7 @@
           "CVMs"
         ],
         "summary": "Provision compose file update",
-        "description": "Validates new compose file and returns compose_hash for on-chain registration. Cache expires after 7 days.",
+        "description": "Validates new compose file and returns compose_hash for on-chain registration. Cache expires after 14 days.",
         "operationId": "provision_for_cvm_compose_file_update_api_v1_cvms__cvm_id__compose_file_provision_post",
         "parameters": [
           {
@@ -2482,165 +590,6 @@
         }
       }
     },
-    "/api/v1/cvms/{cvm_id}/compose": {
-      "get": {
-        "tags": [
-          "CVMs"
-        ],
-        "summary": "Get compose with metadata (legacy)",
-        "description": "Deprecated. Returns compose file with env pubkey and salt.",
-        "operationId": "handle_get_cvm_compose_api_v1_cvms__cvm_id__compose_get",
-        "deprecated": true,
-        "parameters": [
-          {
-            "name": "cvm_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Cvm Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CvmComposeFile"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "CVMs"
-        ],
-        "summary": "Replace compose file (legacy)",
-        "description": "Deprecated. Replaces entire compose configuration and restarts CVM.",
-        "operationId": "handle_update_cvm_compose_api_v1_cvms__cvm_id__compose_put",
-        "deprecated": true,
-        "parameters": [
-          {
-            "name": "cvm_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Cvm Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CvmUpgradePayload",
-                "description": "Complete upgrade payload"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "202": {
-            "description": "Update initiated"
-          },
-          "400": {
-            "description": "Empty Docker Compose or terms violation"
-          },
-          "422": {
-            "description": "Invalid Docker Compose syntax"
-          },
-          "503": {
-            "description": "Node under maintenance"
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "CVMs"
-        ],
-        "summary": "Patch compose file (deprecated, use PATCH /cvms/{cvm_id})",
-        "description": "Deprecated. Use PATCH /cvms/{cvm_id} instead. Partially updates compose file fields (docker_compose_file, pre_launch_script, env) without replacing unchanged parts.",
-        "operationId": "handle_patch_cvm_compose_api_v1_cvms__cvm_id__compose_patch",
-        "deprecated": true,
-        "parameters": [
-          {
-            "name": "cvm_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Cvm Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ComposeFilePatchRequest",
-                "description": "Fields to update"
-              }
-            }
-          }
-        },
-        "responses": {
-          "202": {
-            "description": "Update initiated",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "400": {
-            "description": "Empty Docker Compose or terms violation"
-          },
-          "401": {
-            "description": "Authentication required"
-          },
-          "403": {
-            "description": "CVM not in workspace"
-          },
-          "404": {
-            "description": "CVM not found"
-          },
-          "422": {
-            "description": "Invalid Docker Compose syntax"
-          },
-          "500": {
-            "description": "Failed to get current compose"
-          },
-          "503": {
-            "description": "Node under maintenance or offline"
-          }
-        }
-      }
-    },
     "/api/v1/cvms/{cvm_id}/replicas": {
       "post": {
         "tags": [
@@ -2658,6 +607,22 @@
               "type": "string",
               "title": "Cvm Id"
             }
+          },
+          {
+            "name": "X-Prepare-Only",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Prepare-Only"
+            }
           }
         ],
         "requestBody": {
@@ -2666,7 +631,7 @@
               "schema": {
                 "anyOf": [
                   {
-                    "$ref": "#/components/schemas/teehouse__api__routes__cvms__deployment__ReplicateRequest"
+                    "$ref": "#/components/schemas/ReplicateRequest"
                   },
                   {
                     "type": "null"
@@ -2846,6 +811,61 @@
           },
           "404": {
             "description": "CVM not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/cvms/{cvm_id}/operations/cancel": {
+      "post": {
+        "tags": [
+          "CVMs"
+        ],
+        "summary": "Cancel in-progress CVM operation",
+        "description": "Cancel the current in-progress operation for a CVM. Revokes the Celery task and clears the operation lock.",
+        "operationId": "cancel_cvm_operation_api_v1_cvms__cvm_id__operations_cancel_post",
+        "parameters": [
+          {
+            "name": "cvm_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cvm Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation cancelled or no operation to cancel",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CancelOperationRequest"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "403": {
+            "description": "CVM not in workspace"
+          },
+          "404": {
+            "description": "CVM not found"
+          },
+          "409": {
+            "description": "Cannot cancel this operation type"
           },
           "422": {
             "description": "Validation Error",
@@ -3945,75 +1965,6 @@
         }
       }
     },
-    "/api/v1/cvms/{cvm_id}/visibility": {
-      "patch": {
-        "tags": [
-          "CVMs"
-        ],
-        "summary": "Update visibility settings (deprecated, use PATCH /cvms/{cvm_id})",
-        "description": "Deprecated. Use PATCH /cvms/{cvm_id} instead. Sets public_sysinfo and public_logs flags. Restarts CVM to apply.",
-        "operationId": "handle_update_cvm_visibility_api_v1_cvms__cvm_id__visibility_patch",
-        "deprecated": true,
-        "parameters": [
-          {
-            "name": "cvm_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Cvm Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_handle_update_cvm_visibility_api_v1_cvms__cvm_id__visibility_patch"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Updated CVM record",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VM"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required"
-          },
-          "403": {
-            "description": "CVM not in workspace"
-          },
-          "404": {
-            "description": "CVM not found"
-          },
-          "409": {
-            "description": "Another operation in progress"
-          },
-          "500": {
-            "description": "Failed to get VM info"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/v1/cvms/{cvm_id}/stats": {
       "get": {
         "tags": [
@@ -4052,50 +2003,6 @@
           },
           "404": {
             "description": "CVM not found"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/cvms/{cvm_id}/composition": {
-      "get": {
-        "tags": [
-          "CVMs"
-        ],
-        "summary": "Get CVM composition (deprecated)",
-        "description": "Deprecated. Returns container composition and runtime config.",
-        "operationId": "handle_get_cvm_composition_api_v1_cvms__cvm_id__composition_get",
-        "deprecated": true,
-        "parameters": [
-          {
-            "name": "cvm_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Cvm Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CvmComposition"
-                }
-              }
-            }
           },
           "422": {
             "description": "Validation Error",
@@ -4499,70 +2406,6 @@
         }
       }
     },
-    "/api/v1/cvms/{cvm_id}/resources": {
-      "patch": {
-        "tags": [
-          "CVMs"
-        ],
-        "summary": "Resize CVM resources (deprecated, use PATCH /cvms/{cvm_id})",
-        "description": "Deprecated. Use PATCH /cvms/{cvm_id} instead. Changes vCPU, memory, or disk size. Restarts CVM to apply. Triggers billing for new rate.",
-        "operationId": "handle_resize_cvm_api_v1_cvms__cvm_id__resources_patch",
-        "deprecated": true,
-        "parameters": [
-          {
-            "name": "cvm_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Cvm Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CvmResizePayload"
-              }
-            }
-          }
-        },
-        "responses": {
-          "202": {
-            "description": "Resize initiated",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required"
-          },
-          "403": {
-            "description": "CVM managed by on-demand GPU rental"
-          },
-          "404": {
-            "description": "CVM not found"
-          },
-          "409": {
-            "description": "Another operation in progress"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/v1/cvms/{cvm_id}/name": {
       "patch": {
         "tags": [
@@ -4902,6 +2745,280 @@
         }
       }
     },
+    "/api/v1/cvms/{cvm_id}/network-config": {
+      "get": {
+        "tags": [
+          "CVMs",
+          "cvms-network-config"
+        ],
+        "summary": "Get network configuration",
+        "description": "Returns real-time KMS URLs, Gateway URLs, and port mappings from VMM.",
+        "operationId": "handle_get_network_config_api_v1_cvms__cvm_id__network_config_get",
+        "parameters": [
+          {
+            "name": "cvm_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cvm Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Network configuration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NetworkConfigResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "CVM not found"
+          },
+          "500": {
+            "description": "Failed to query VMM"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "CVMs",
+          "cvms-network-config"
+        ],
+        "summary": "Update KMS/Gateway URLs",
+        "description": "Update KMS and/or Gateway URLs for this CVM. Requires VMM >= 0.5.7.",
+        "operationId": "handle_update_network_config_api_v1_cvms__cvm_id__network_config_patch",
+        "parameters": [
+          {
+            "name": "cvm_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cvm Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateNetworkConfigRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated network configuration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NetworkConfigResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "VMM too old or invalid request"
+          },
+          "403": {
+            "description": "Feature not enabled for this workspace"
+          },
+          "404": {
+            "description": "CVM not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/cvms/{cvm_id}/ports": {
+      "get": {
+        "tags": [
+          "CVMs",
+          "cvms-network-config"
+        ],
+        "summary": "Get port mappings",
+        "description": "Returns persisted port mappings for this CVM.",
+        "operationId": "handle_get_port_mappings_api_v1_cvms__cvm_id__ports_get",
+        "parameters": [
+          {
+            "name": "cvm_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cvm Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Port mappings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PortMappingResponse"
+                  },
+                  "title": "Response Handle Get Port Mappings Api V1 Cvms  Cvm Id  Ports Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "CVM not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "CVMs",
+          "cvms-network-config"
+        ],
+        "summary": "Set port mappings",
+        "description": "Bulk-replace all port mappings for this CVM. Writes to DB and applies to VMM.",
+        "operationId": "handle_set_port_mappings_api_v1_cvms__cvm_id__ports_put",
+        "parameters": [
+          {
+            "name": "cvm_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cvm Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatePortMappingsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated port mappings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PortMappingResponse"
+                  },
+                  "title": "Response Handle Set Port Mappings Api V1 Cvms  Cvm Id  Ports Put"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "403": {
+            "description": "Feature not enabled for this workspace"
+          },
+          "409": {
+            "description": "Port conflict during concurrent updates"
+          },
+          "404": {
+            "description": "CVM not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/cvms/{cvm_id}/firewall-status": {
+      "get": {
+        "tags": [
+          "CVMs",
+          "cvms-network-config"
+        ],
+        "summary": "Get firewall availability for this CVM's node",
+        "description": "Checks teescope capabilities.firewall on the node hosting this CVM.",
+        "operationId": "handle_get_firewall_status_api_v1_cvms__cvm_id__firewall_status_get",
+        "parameters": [
+          {
+            "name": "cvm_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cvm Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FirewallStatusResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/cvms/{cvm_id}/commit-update": {
       "get": {
         "tags": [
@@ -5003,6 +3120,79 @@
         },
         "responses": {
           "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/cvms/{cvm_id}/commit-replica": {
+      "post": {
+        "tags": [
+          "CVMs"
+        ],
+        "summary": "Commit CVM replica (token-based, no auth required)",
+        "description": "Completes a two-phase CVM replication using a one-time commit token. The token was generated during a prepare-only or hash-required replica request.",
+        "operationId": "commit_cvm_replica_api_v1_cvms__cvm_id__commit_replica_post",
+        "parameters": [
+          {
+            "name": "cvm_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cvm Id"
+            }
+          },
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Commit token (alternative to body.token)",
+              "title": "Token"
+            },
+            "description": "Commit token (alternative to body.token)"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CommitUpdateRequest",
+                "default": {
+                  "token": "",
+                  "compose_hash": "",
+                  "transaction_hash": ""
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
@@ -5916,6 +4106,22 @@
               "title": "Vm Uuid"
             },
             "description": "Source CVM UUID"
+          },
+          {
+            "name": "X-Prepare-Only",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Prepare-Only"
+            }
           }
         ],
         "requestBody": {
@@ -5924,7 +4130,7 @@
               "schema": {
                 "anyOf": [
                   {
-                    "$ref": "#/components/schemas/teehouse__api__routes__apps__schemas__ReplicateRequest"
+                    "$ref": "#/components/schemas/ReplicateRequest"
                   },
                   {
                     "type": "null"
@@ -5960,6 +4166,78 @@
           },
           "500": {
             "description": "Replication failed"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/apps/{app_id}/instances": {
+      "post": {
+        "tags": [
+          "Apps"
+        ],
+        "summary": "Create a new instance under an existing app",
+        "description": "Deploy a new CVM instance under an existing app, optionally with a new Docker Compose file. For on-chain KMS apps, this uses a two-phase flow: the first request returns HTTP 465 with a commit token; after registering the compose hash on-chain, the second request commits with the token and transaction hash.",
+        "operationId": "handle_create_app_instance_api_v1_apps__app_id__instances_post",
+        "parameters": [
+          {
+            "name": "app_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Hex app identifier",
+              "title": "App Id"
+            },
+            "description": "Hex app identifier"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAppInstanceRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Instance created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VM"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid compose, no template instance, or app mismatch"
+          },
+          "401": {
+            "description": "Not authenticated"
+          },
+          "403": {
+            "description": "No workspace access"
+          },
+          "404": {
+            "description": "App or target node not found"
+          },
+          "465": {
+            "description": "On-chain compose hash registration required (two-phase flow)"
+          },
+          "500": {
+            "description": "Instance creation failed"
           },
           "422": {
             "description": "Validation Error",
@@ -6052,6 +4330,54 @@
             "content": {
               "application/json": {
                 "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "App not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/apps/{app_id}/attestations/tcb-evaluation": {
+      "get": {
+        "tags": [
+          "Apps"
+        ],
+        "summary": "Run app TCB evaluation",
+        "description": "Runs a live Intel PCS early collateral evaluation for each running CVM without using Redis collateral cache.",
+        "operationId": "handle_get_app_tcb_evaluation_api_v1_apps__app_id__attestations_tcb_evaluation_get",
+        "parameters": [
+          {
+            "name": "app_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Hex app identifier",
+              "title": "App Id"
+            },
+            "description": "Hex app identifier"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "TCB evaluation results for running instances",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TcbEvaluationResponse"
+                }
               }
             }
           },
@@ -6330,165 +4656,6 @@
         }
       }
     },
-    "/api/v1/apps/{app_id}/events": {
-      "get": {
-        "tags": [
-          "Apps"
-        ],
-        "summary": "Get app events",
-        "description": "**DEPRECATED**: Returns instance lifecycle events from ClickHouse. Will be removed.",
-        "operationId": "get_app_events_api_v1_apps__app_id__events_get",
-        "deprecated": true,
-        "parameters": [
-          {
-            "name": "app_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Hex app identifier",
-              "title": "App Id"
-            },
-            "description": "Hex app identifier"
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 1000,
-              "minimum": 1,
-              "description": "Max events to return",
-              "default": 100,
-              "title": "Limit"
-            },
-            "description": "Max events to return"
-          },
-          {
-            "name": "event_type",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Filter by event type",
-              "title": "Event Type"
-            },
-            "description": "Filter by event type"
-          },
-          {
-            "name": "instance_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Filter by instance UUID",
-              "title": "Instance Id"
-            },
-            "description": "Filter by instance UUID"
-          },
-          {
-            "name": "operation_type",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Filter by operation type",
-              "title": "Operation Type"
-            },
-            "description": "Filter by operation type"
-          },
-          {
-            "name": "start_date",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Start date (ISO 8601)",
-              "title": "Start Date"
-            },
-            "description": "Start date (ISO 8601)"
-          },
-          {
-            "name": "end_date",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "End date (ISO 8601)",
-              "title": "End Date"
-            },
-            "description": "End date (ISO 8601)"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Event list",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppEventsResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "403": {
-            "description": "No workspace access"
-          },
-          "404": {
-            "description": "App not found"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/v1/apps/{app_id}/usage": {
       "get": {
         "tags": [
@@ -6711,199 +4878,35 @@
         }
       }
     },
-    "/api/v1/tokens": {
+    "/api/v1/apps/{app_id}/kms-info": {
       "get": {
         "tags": [
-          "Tokens"
+          "Apps",
+          "apps-kms-info"
         ],
-        "summary": "List API tokens",
-        "description": "Return tokens for the current workspace. Set all_workspaces=true to include tokens from all workspaces the user owns.",
-        "operationId": "list_tokens_api_v1_tokens_get",
+        "summary": "Get app on-chain KMS info",
+        "description": "Returns on-chain KMS metadata for an app: chain, KMS contract, app contract, deployer address, and deployer type detection (EOA, Safe multisig, legacy multisig, ERC-4337, or generic contract).",
+        "operationId": "get_app_kms_info_api_v1_apps__app_id__kms_info_get",
         "parameters": [
           {
-            "name": "all_workspaces",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "All Workspaces"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ApiToken"
-                  },
-                  "title": "Response List Tokens Api V1 Tokens Get"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "403": {
-            "description": "No workspace access"
-          },
-          "500": {
-            "description": "Token retrieval failed"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Tokens"
-        ],
-        "summary": "Create API token",
-        "description": "Create a new API token scoped to the current workspace. The raw token value is only returned once.",
-        "operationId": "create_token_api_v1_tokens_post",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ApiTokenCreate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiToken"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "403": {
-            "description": "No workspace access"
-          },
-          "404": {
-            "description": "Token not found after creation"
-          },
-          "500": {
-            "description": "Failed to load workspace or user"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/tokens/{token_id}": {
-      "delete": {
-        "tags": [
-          "Tokens"
-        ],
-        "summary": "Revoke API token",
-        "description": "Permanently revoke a token owned by the current user. Cannot be undone.",
-        "operationId": "revoke_token_api_v1_tokens__token_id__delete",
-        "parameters": [
-          {
-            "name": "token_id",
+            "name": "app_id",
             "in": "path",
             "required": true,
             "schema": {
-              "type": "integer",
-              "title": "Token Id"
-            }
+              "type": "string",
+              "description": "Hex app identifier",
+              "title": "App Id"
+            },
+            "description": "Hex app identifier"
           }
         ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "400": {
-            "description": "Token already revoked"
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "404": {
-            "description": "Token not found or no access"
-          },
-          "500": {
-            "description": "Revocation failed"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/tokens/{token_id}/refresh": {
-      "post": {
-        "tags": [
-          "Tokens"
-        ],
-        "summary": "Refresh API token",
-        "description": "Extend expiration or upgrade to the latest API version. Does not regenerate the token secret.",
-        "operationId": "refresh_token_api_v1_tokens__token_id__refresh_post",
-        "parameters": [
-          {
-            "name": "token_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Token Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ApiTokenRefresh"
-              }
-            }
-          }
-        },
         "responses": {
           "200": {
-            "description": "Successful Response",
+            "description": "KMS info",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ApiToken"
+                  "$ref": "#/components/schemas/AppKmsInfoResponse"
                 }
               }
             }
@@ -6912,10 +4915,7 @@
             "description": "Not authenticated"
           },
           "404": {
-            "description": "Token not found, inactive, or no access"
-          },
-          "500": {
-            "description": "Refresh failed"
+            "description": "App not found"
           },
           "422": {
             "description": "Validation Error",
@@ -6930,284 +4930,44 @@
         }
       }
     },
-    "/api/v1/charge": {
-      "post": {
-        "tags": [
-          "Billing"
-        ],
-        "summary": "Create payment charge",
-        "description": "Creates a payment order with the specified provider (Coinbase, Square, Stripe, or Mock). For Stripe with saved card, attempts direct charge before falling back to checkout session. Returns hosted_url for redirect-based flows or status for direct charges.",
-        "operationId": "create_charge_api_v1_charge_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ChargeRequest",
-                "description": "Payment amount, provider, and optional code/invoice_id"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Charge created with provider-specific response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "400": {
-            "description": "Team has no credit, Square disabled, or unsupported provider"
-          },
-          "500": {
-            "description": "Payment provider API error"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/orders": {
+    "/api/v1/apps/{app_id}/pending-updates": {
       "get": {
         "tags": [
-          "Billing"
+          "Apps",
+          "apps-pending-updates"
         ],
-        "summary": "List payment orders",
-        "description": "Returns paginated orders with cursor-based pagination. Excludes 'created' status by default. Admins can query by user_id.",
-        "operationId": "handle_list_orders_api_v1_orders_get",
+        "summary": "Get pending compose updates",
+        "description": "Returns provisioned compose file updates that have been signed on-chain but not yet applied to CVMs.",
+        "operationId": "get_pending_updates_api_v1_apps__app_id__pending_updates_get",
         "parameters": [
           {
-            "name": "cursor",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Hashid-encoded cursor from previous response",
-              "title": "Cursor"
-            },
-            "description": "Hashid-encoded cursor from previous response"
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "description": "Items per page (1-100)",
-              "default": 20,
-              "title": "Limit"
-            },
-            "description": "Items per page (1-100)"
-          },
-          {
-            "name": "provider",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/PaymentProvider"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Filter: coinbase, square, stripe, mock",
-              "title": "Provider"
-            },
-            "description": "Filter: coinbase, square, stripe, mock"
-          },
-          {
-            "name": "status",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/OrderStatus"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Filter: created, submitted, pending, purchased, finalized, failed",
-              "title": "Status"
-            },
-            "description": "Filter: created, submitted, pending, purchased, finalized, failed"
-          },
-          {
-            "name": "user_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "format": "hashid",
-                  "description": "A hashed identifier that maps to an internal database ID",
-                  "pattern": "^usr_.+",
-                  "title": "HashedId[users]",
-                  "examples": [
-                    "usr_0123abcd"
-                  ]
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Target user ID (admin only)",
-              "title": "User Id"
-            },
-            "description": "Target user ID (admin only)"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Paginated orders with has_more and next_cursor",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrdersListResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid cursor format"
-          },
-          "403": {
-            "description": "Non-admin tried to query another user's orders"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/debt": {
-      "get": {
-        "tags": [
-          "Billing"
-        ],
-        "summary": "Get outstanding debt",
-        "description": "Returns the total overdue payment amount for the current workspace. Zero if no debt exists.",
-        "operationId": "handle_get_debt_api_v1_debt_get",
-        "responses": {
-          "200": {
-            "description": "Debt amount (Money type, quantized)",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/debt/settlement": {
-      "post": {
-        "tags": [
-          "Billing"
-        ],
-        "summary": "Settle outstanding debt",
-        "description": "Pays off outstanding debt using available credit balance. Deducts from granted_balance first, then balance.",
-        "operationId": "handle_debt_settlement_api_v1_debt_settlement_post",
-        "responses": {
-          "202": {
-            "description": "Debt settled with breakdown of amounts used",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "400": {
-            "description": "No debt to settle, insufficient balance, or credit account missing"
-          },
-          "500": {
-            "description": "Unexpected settlement state"
-          }
-        }
-      }
-    },
-    "/api/v1/card": {
-      "get": {
-        "tags": [
-          "Billing"
-        ],
-        "summary": "Get saved card info",
-        "description": "Returns the last4, brand, and payment_method_id of the user's verified card. Includes a Stripe billing portal URL for card management.",
-        "operationId": "get_card_info_api_v1_card_get",
-        "responses": {
-          "200": {
-            "description": "Card info with found=true, or found=false if no verified card",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/card/{payment_method_id}": {
-      "delete": {
-        "tags": [
-          "Billing"
-        ],
-        "summary": "Remove saved card",
-        "description": "Detaches the payment method from Stripe, marks verification as failed, clears default payment method, and downgrades team tier to LEVEL_1.",
-        "operationId": "remove_card_api_v1_card__payment_method_id__delete",
-        "parameters": [
-          {
-            "name": "payment_method_id",
+            "name": "app_id",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "description": "Stripe payment method ID (pm_...)",
-              "title": "Payment Method Id"
+              "description": "Hex app identifier",
+              "title": "App Id"
             },
-            "description": "Stripe payment method ID (pm_...)"
+            "description": "Hex app identifier"
           }
         ],
         "responses": {
           "200": {
-            "description": "Card removed successfully",
+            "description": "Pending updates list",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/PendingUpdatesResponse"
+                }
               }
             }
           },
+          "401": {
+            "description": "Not authenticated"
+          },
           "404": {
-            "description": "Card not found or not owned by user"
+            "description": "App not found"
           },
           "422": {
             "description": "Validation Error",
@@ -7222,954 +4982,66 @@
         }
       }
     },
-    "/api/v1/credits": {
+    "/api/v1/apps/{app_id}/pending-updates/{vm_uuid}/{compose_hash}/preview": {
       "get": {
         "tags": [
-          "Billing"
+          "Apps",
+          "apps-pending-updates"
         ],
-        "summary": "Get credit balance",
-        "description": "Returns the user's credit account with balance, granted_balance, and Stripe customer ID.",
-        "operationId": "get_credits_api_v1_credits_get",
-        "responses": {
-          "200": {
-            "description": "Credit account details",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/teehouse__models__schemas__credits__Credit"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "User has no credit account"
-          }
-        }
-      }
-    },
-    "/api/v1/billing/balance": {
-      "get": {
-        "tags": [
-          "Billing"
-        ],
-        "summary": "Get workspace billing balance",
-        "description": "Returns the current workspace's credit balance, granted balance, outstanding debt, and tier.",
-        "operationId": "get_billing_balance_api_v1_billing_balance_get",
-        "responses": {
-          "200": {
-            "description": "Workspace billing balance",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BillingBalanceResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Workspace has no credit account"
-          }
-        }
-      }
-    },
-    "/api/v1/credits/transactions": {
-      "get": {
-        "tags": [
-          "Billing"
-        ],
-        "summary": "List credit transactions",
-        "description": "Returns paginated credit transactions with filtering by type and paid status. Includes total_amount sum for filtered results.",
-        "operationId": "handle_list_transactions_api_v1_credits_transactions_get",
+        "summary": "Preview a pending compose update",
+        "description": "Returns current and pending docker compose file and pre-launch script for diffing before applying an update.",
+        "operationId": "get_pending_update_preview_api_v1_apps__app_id__pending_updates__vm_uuid___compose_hash__preview_get",
         "parameters": [
           {
-            "name": "page",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 1,
-              "title": "Page"
-            }
-          },
-          {
-            "name": "page_size",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "default": 30,
-              "title": "Page Size"
-            }
-          },
-          {
-            "name": "type",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Type"
-            }
-          },
-          {
-            "name": "has_paid",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Has Paid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Paginated transactions with total_amount",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/teehouse__api__routes__billing__credits__PaginatedCreditTransactions"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "User has no credit account"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/credits/redeem": {
-      "post": {
-        "tags": [
-          "Billing"
-        ],
-        "summary": "Redeem promotion code",
-        "description": "Applies a promotion code to add credits to the account. Admins can specify target_user_id or target_team_id to redeem for others.",
-        "operationId": "handle_redeem_promotion_code_api_v1_credits_redeem_post",
-        "parameters": [
-          {
-            "name": "code",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Promotion code string",
-              "title": "Code"
-            },
-            "description": "Promotion code string"
-          },
-          {
-            "name": "target_user_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Target user ID (admin only)",
-              "title": "Target User Id"
-            },
-            "description": "Target user ID (admin only)"
-          },
-          {
-            "name": "target_team_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Target team ID (admin only)",
-              "title": "Target Team Id"
-            },
-            "description": "Target team ID (admin only)"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Updated credit account after redemption",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/teehouse__models__schemas__credits__Credit"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid code, expired, max uses reached, or user limit reached"
-          },
-          "403": {
-            "description": "Non-admin tried to redeem for another user/team"
-          },
-          "404": {
-            "description": "Target user or team not found"
-          },
-          "500": {
-            "description": "Unexpected error during redemption"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/billing": {
-      "get": {
-        "tags": [
-          "Billing",
-          "Usage"
-        ],
-        "summary": "Get billing summary",
-        "description": "Returns monthly total, 7-day total, daily usage breakdown, and per-instance spending. Filter by CVM identifier or use admin access to view other users.",
-        "operationId": "handle_get_billing_summary_api_v1_billing_get",
-        "parameters": [
-          {
-            "name": "identifier",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "CVM identifier to filter by (app_id or vm_uuid)",
-              "title": "Identifier"
-            },
-            "description": "CVM identifier to filter by (app_id or vm_uuid)"
-          },
-          {
-            "name": "user_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "format": "hashid",
-                  "description": "A hashed identifier that maps to an internal database ID",
-                  "pattern": "^usr_.+",
-                  "title": "HashedId[users]",
-                  "examples": [
-                    "usr_0123abcd"
-                  ]
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Target user ID (admin only)",
-              "title": "User Id"
-            },
-            "description": "Target user ID (admin only)"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Billing summary with totals and breakdowns",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/teehouse__api__routes__billing__usage__BillingSummaryResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Admin-only: non-admin tried to view another user's billing"
-          },
-          "404": {
-            "description": "Admin-only: specified user not found"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/billing/billing_items": {
-      "get": {
-        "tags": [
-          "Billing",
-          "Usage"
-        ],
-        "summary": "List billing items",
-        "description": "Returns hourly billing records with per-event details. Supports cursor pagination. Admins can query by team_id or user_id.",
-        "operationId": "handle_list_billing_items_api_v1_billing_billing_items_get",
-        "parameters": [
-          {
-            "name": "cursor",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Hashid-encoded cursor from previous response",
-              "title": "Cursor"
-            },
-            "description": "Hashid-encoded cursor from previous response"
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 500,
-              "minimum": 1,
-              "description": "Items per page (1-500)",
-              "default": 50,
-              "title": "Limit"
-            },
-            "description": "Items per page (1-500)"
-          },
-          {
-            "name": "team_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "format": "hashid",
-                  "description": "A hashed identifier that maps to an internal database ID",
-                  "pattern": "^wks_.+",
-                  "title": "HashedId[teams]",
-                  "examples": [
-                    "wks_0123abcd"
-                  ]
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Target team ID (admin only)",
-              "title": "Team Id"
-            },
-            "description": "Target team ID (admin only)"
-          },
-          {
-            "name": "user_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "format": "hashid",
-                  "description": "A hashed identifier that maps to an internal database ID",
-                  "pattern": "^usr_.+",
-                  "title": "HashedId[users]",
-                  "examples": [
-                    "usr_0123abcd"
-                  ]
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Target user ID (admin only)",
-              "title": "User Id"
-            },
-            "description": "Target user ID (admin only)"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Paginated billing items with next_cursor and total",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaginatedBillingItemsResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid cursor format"
-          },
-          "403": {
-            "description": "Admin-only: non-admin tried to query other team/user"
-          },
-          "404": {
-            "description": "Admin-only: specified team or user not found"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/billing/billing_items/{cvm_id}": {
-      "get": {
-        "tags": [
-          "Billing",
-          "Usage"
-        ],
-        "summary": "List billing items by instance",
-        "description": "Returns hourly billing records for a specific CVM. Supports cursor pagination.",
-        "operationId": "handle_list_billing_items_by_instance_api_v1_billing_billing_items__cvm_id__get",
-        "parameters": [
-          {
-            "name": "cvm_id",
+            "name": "app_id",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Cvm Id"
-            }
-          },
-          {
-            "name": "cursor",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Hashid-encoded cursor from previous response",
-              "title": "Cursor"
+              "description": "Hex app identifier",
+              "title": "App Id"
             },
-            "description": "Hashid-encoded cursor from previous response"
+            "description": "Hex app identifier"
           },
           {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 500,
-              "minimum": 1,
-              "description": "Items per page (1-500)",
-              "default": 50,
-              "title": "Limit"
-            },
-            "description": "Items per page (1-500)"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Paginated billing items for the instance",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaginatedBillingItemsResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid cursor format"
-          },
-          "404": {
-            "description": "CVM not found or not accessible"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/billing/invoices": {
-      "get": {
-        "tags": [
-          "Billing"
-        ],
-        "summary": "List invoices",
-        "description": "Returns paginated visible invoices for the current workspace, sorted by creation date (newest first). Filter by status: open, paid, uncollectible.",
-        "operationId": "list_invoices_api_v1_billing_invoices_get",
-        "parameters": [
-          {
-            "name": "skip",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "description": "Number of items to skip",
-              "default": 0,
-              "title": "Skip"
-            },
-            "description": "Number of items to skip"
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "description": "Items per page (1-100)",
-              "default": 20,
-              "title": "Limit"
-            },
-            "description": "Items per page (1-100)"
-          },
-          {
-            "name": "status",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Filter: open, paid, uncollectible",
-              "title": "Status"
-            },
-            "description": "Filter: open, paid, uncollectible"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Paginated invoice list with total count",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InvoiceListResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/billing/invoices/{invoice_id}": {
-      "get": {
-        "tags": [
-          "Billing"
-        ],
-        "summary": "Get invoice details",
-        "description": "Returns full invoice details including team balance and payment URLs. User must be a workspace member.",
-        "operationId": "get_invoice_api_v1_billing_invoices__invoice_id__get",
-        "parameters": [
-          {
-            "name": "invoice_id",
+            "name": "vm_uuid",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "description": "Invoice ID (integer or hashid)",
-              "title": "Invoice Id"
+              "description": "VM UUID",
+              "title": "Vm Uuid"
             },
-            "description": "Invoice ID (integer or hashid)"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Invoice details with payment options",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InvoiceDetailResponse"
-                }
-              }
-            }
+            "description": "VM UUID"
           },
-          "400": {
-            "description": "Invalid invoice ID format"
-          },
-          "403": {
-            "description": "User is not a member of the invoice's workspace"
-          },
-          "404": {
-            "description": "Invoice not found"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/billing/invoices/{invoice_id}/items": {
-      "get": {
-        "tags": [
-          "Billing"
-        ],
-        "summary": "Get invoice line items",
-        "description": "Returns line items for an invoice with instance name, type, region, and cost. User must be a workspace member.",
-        "operationId": "get_invoice_items_api_v1_billing_invoices__invoice_id__items_get",
-        "parameters": [
           {
-            "name": "invoice_id",
+            "name": "compose_hash",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "description": "Invoice ID (integer or hashid)",
-              "title": "Invoice Id"
+              "description": "Compose hash of the pending update",
+              "title": "Compose Hash"
             },
-            "description": "Invoice ID (integer or hashid)"
+            "description": "Compose hash of the pending update"
           }
         ],
         "responses": {
           "200": {
-            "description": "List of invoice items",
+            "description": "Preview data",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/InvoiceItemResponse"
-                  },
-                  "title": "Response Get Invoice Items Api V1 Billing Invoices  Invoice Id  Items Get"
+                  "$ref": "#/components/schemas/PendingUpdatePreview"
                 }
               }
             }
           },
-          "400": {
-            "description": "Invalid invoice ID format"
-          },
-          "403": {
-            "description": "User is not a member of the invoice's workspace"
+          "401": {
+            "description": "Not authenticated"
           },
           "404": {
-            "description": "Invoice not found"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/billing/invoices/{invoice_id}/pay": {
-      "post": {
-        "tags": [
-          "Billing"
-        ],
-        "summary": "Pay invoice with credits",
-        "description": "Pays an open invoice using credit balance. Deducts from granted_balance first, then balance. Only credit_balance payment method is supported.",
-        "operationId": "pay_invoice_api_v1_billing_invoices__invoice_id__pay_post",
-        "parameters": [
-          {
-            "name": "invoice_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Invoice ID (integer or hashid)",
-              "title": "Invoice Id"
-            },
-            "description": "Invoice ID (integer or hashid)"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PayInvoiceRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Payment succeeded with breakdown of used balances",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PayInvoiceResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid invoice ID, unsupported payment method, or invoice not open"
-          },
-          "402": {
-            "description": "Insufficient credit balance to pay the invoice"
-          },
-          "403": {
-            "description": "User is not a member of the invoice's workspace"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/billing/settings": {
-      "get": {
-        "tags": [
-          "Billing"
-        ],
-        "summary": "Get billing settings",
-        "description": "Returns the workspace billing email and Stripe customer email for consistency check.",
-        "operationId": "get_billing_settings_api_v1_billing_settings_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BillingSettingsResponse"
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "Billing"
-        ],
-        "summary": "Update billing settings",
-        "description": "Update the workspace billing email. Syncs to Stripe customer if linked. Requires OWNER or ADMIN role.",
-        "operationId": "update_billing_settings_api_v1_billing_settings_patch",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateBillingSettingsRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BillingSettingsResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/setup-billing/create-intent": {
-      "post": {
-        "tags": [
-          "Billing"
-        ],
-        "summary": "Create card verification intent",
-        "description": "Creates a Stripe PaymentIntent for a $1 card verification charge. The charge is refunded after verification completes.",
-        "operationId": "handle_create_payment_intent_api_v1_setup_billing_create_intent_post",
-        "responses": {
-          "200": {
-            "description": "Returns client_secret and order_id for frontend completion",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "400": {
-            "description": "Team has no credit account"
-          },
-          "500": {
-            "description": "Failed to create Stripe customer or customer ID missing"
-          }
-        }
-      }
-    },
-    "/api/v1/setup-billing/save-intent": {
-      "post": {
-        "tags": [
-          "Billing"
-        ],
-        "summary": "Complete card verification",
-        "description": "Verifies the payment method, stores card fingerprint, upgrades team tier to LEVEL_2, and sets the card as default payment method. Triggers refund on failure.",
-        "operationId": "handle_save_intent_api_v1_setup_billing_save_intent_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_handle_save_intent_api_v1_setup_billing_save_intent_post"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "202": {
-            "description": "Verification completed, tier upgraded",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "400": {
-            "description": "Team has no credit, payment incomplete, or duplicate card"
-          },
-          "404": {
-            "description": "Verification order not found"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/setup-billing/check": {
-      "get": {
-        "tags": [
-          "Billing"
-        ],
-        "summary": "Check verification order status",
-        "description": "Returns whether the setup billing order has been verified. Frontend polls this after payment completion.",
-        "operationId": "handle_check_setup_billing_api_v1_setup_billing_check_get",
-        "parameters": [
-          {
-            "name": "order_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Hashid-encoded order ID from create-intent response",
-              "title": "Order Id"
-            },
-            "description": "Hashid-encoded order ID from create-intent response"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Returns verified boolean and optional message",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid or malformed order ID"
+            "description": "App or pending update not found"
           },
           "422": {
             "description": "Validation Error",
@@ -8615,223 +5487,56 @@
         }
       }
     },
-    "/api/v1/workspaces": {
+    "/api/v1/workspace/webhooks": {
       "get": {
         "tags": [
-          "Workspace"
+          "Webhooks"
         ],
-        "summary": "List user workspaces",
-        "description": "Returns all workspaces the authenticated user has access to, with their role in each.",
-        "operationId": "list_user_workspaces_api_v1_workspaces_get",
-        "responses": {
-          "200": {
-            "description": "List of workspaces with user roles",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkspacesListResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required"
-          }
-        }
-      }
-    },
-    "/api/v1/workspaces/{team_slug}": {
-      "get": {
-        "tags": [
-          "Workspace"
-        ],
-        "summary": "Get workspace by slug",
-        "description": "Returns workspace details if user has access.",
-        "operationId": "get_workspace_info_api_v1_workspaces__team_slug__get",
-        "parameters": [
-          {
-            "name": "team_slug",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Team Slug"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Workspace details",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkspaceResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required"
-          },
-          "403": {
-            "description": "User not a member of workspace"
-          },
-          "404": {
-            "description": "Workspace not found"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/workspaces/{team_slug}/nodes": {
-      "get": {
-        "tags": [
-          "Workspace"
-        ],
-        "summary": "List workspace nodes",
-        "description": "Returns nodes (backed by teepods) accessible to this workspace: reserved nodes first, then public nodes.",
-        "operationId": "list_workspace_nodes_api_v1_workspaces__team_slug__nodes_get",
-        "parameters": [
-          {
-            "name": "team_slug",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Team Slug"
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 1,
-              "title": "Page"
-            }
-          },
-          {
-            "name": "page_size",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "default": 30,
-              "title": "Page Size"
-            }
-          }
-        ],
+        "summary": "List workspace webhooks",
+        "operationId": "list_webhooks_api_v1_workspace_webhooks_get",
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PaginatedWorkspaceNodesResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "items": {
+                    "$ref": "#/components/schemas/WebhookResponse"
+                  },
+                  "type": "array",
+                  "title": "Response List Webhooks Api V1 Workspace Webhooks Get"
                 }
               }
             }
           }
         }
-      }
-    },
-    "/api/v1/workspaces/{team_slug}/quotas": {
-      "get": {
-        "tags": [
-          "Workspace"
-        ],
-        "summary": "Get workspace quotas",
-        "description": "Returns tier quota limit/remaining and reserved GPU availability (reserved pool only).",
-        "operationId": "get_workspace_quotas_api_v1_workspaces__team_slug__quotas_get",
-        "parameters": [
-          {
-            "name": "team_slug",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Team Slug"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkspaceQuotasResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/workspaces/check-slug": {
+      },
       "post": {
         "tags": [
-          "Workspace"
+          "Webhooks"
         ],
-        "summary": "Validate workspace slug",
-        "description": "Checks slug format and reserved words. Does NOT check uniqueness (that happens at creation).",
-        "operationId": "check_workspace_slug_api_v1_workspaces_check_slug_post",
+        "summary": "Create workspace webhook",
+        "operationId": "create_webhook_api_v1_workspace_webhooks_post",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CheckSlugRequest"
+                "$ref": "#/components/schemas/WebhookCreateRequest"
               }
             }
           },
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "Validation result",
+          "201": {
+            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CheckSlugResponse"
+                  "$ref": "#/components/schemas/WebhookResponse"
                 }
               }
             }
-          },
-          "401": {
-            "description": "Authentication required"
           },
           "422": {
             "description": "Validation Error",
@@ -8846,67 +5551,34 @@
         }
       }
     },
-    "/api/v1/workspaces/{workspace_slug}/invitations": {
-      "post": {
+    "/api/v1/workspace/webhooks/{webhook_id}": {
+      "get": {
         "tags": [
-          "Workspace"
+          "Webhooks"
         ],
-        "summary": "Send workspace invitation",
-        "description": "OWNER/ADMIN only. Sends email invitation to join workspace.",
-        "operationId": "create_workspace_invitation_api_v1_workspaces__workspace_slug__invitations_post",
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ],
+        "summary": "Get webhook details",
+        "operationId": "get_webhook_api_v1_workspace_webhooks__webhook_id__get",
         "parameters": [
           {
-            "name": "workspace_slug",
+            "name": "webhook_id",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "description": "Workspace slug",
-              "title": "Workspace Slug"
-            },
-            "description": "Workspace slug"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/InvitationCreateRequest"
-              }
+              "title": "Webhook Id"
             }
           }
-        },
+        ],
         "responses": {
           "200": {
-            "description": "Invitation created",
+            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/InvitationResponse"
+                  "$ref": "#/components/schemas/WebhookResponse"
                 }
               }
             }
-          },
-          "400": {
-            "description": "Invalid role or user already invited"
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "403": {
-            "description": "OWNER/ADMIN only"
-          },
-          "404": {
-            "description": "Workspace not found"
           },
           "422": {
             "description": "Validation Error",
@@ -8920,389 +5592,43 @@
           }
         }
       },
-      "get": {
+      "put": {
         "tags": [
-          "Workspace"
+          "Webhooks"
         ],
-        "summary": "List pending invitations",
-        "description": "OWNER/ADMIN only. Returns paginated list of pending invitations.",
-        "operationId": "list_workspace_invitations_api_v1_workspaces__workspace_slug__invitations_get",
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ],
+        "summary": "Update webhook",
+        "operationId": "update_webhook_api_v1_workspace_webhooks__webhook_id__put",
         "parameters": [
           {
-            "name": "workspace_slug",
+            "name": "webhook_id",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "description": "Workspace slug",
-              "title": "Workspace Slug"
-            },
-            "description": "Workspace slug"
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "description": "Page number",
-              "default": 1,
-              "title": "Page"
-            },
-            "description": "Page number"
-          },
-          {
-            "name": "page_size",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "description": "Items per page",
-              "default": 30,
-              "title": "Page Size"
-            },
-            "description": "Items per page"
+              "title": "Webhook Id"
+            }
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WebhookUpdateRequest"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
-            "description": "Pending invitations",
+            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PaginatedInvitations"
+                  "$ref": "#/components/schemas/WebhookResponse"
                 }
               }
             }
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "403": {
-            "description": "OWNER/ADMIN only"
-          },
-          "404": {
-            "description": "Workspace not found"
-          },
-          "500": {
-            "description": "Database error"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/workspaces/{workspace_slug}/invitations/shareable": {
-      "post": {
-        "tags": [
-          "Workspace"
-        ],
-        "summary": "Create shareable invitation",
-        "description": "OWNER/ADMIN only. Creates link anyone can use to join as MEMBER.",
-        "operationId": "create_shareable_workspace_invitation_api_v1_workspaces__workspace_slug__invitations_shareable_post",
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "workspace_slug",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Workspace slug",
-              "title": "Workspace Slug"
-            },
-            "description": "Workspace slug"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Shareable link created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ShareableInvitationResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Creation failed"
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "403": {
-            "description": "OWNER/ADMIN only"
-          },
-          "404": {
-            "description": "Workspace not found"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/workspaces/{workspace_slug}/invitations/{invitation_id}": {
-      "delete": {
-        "tags": [
-          "Workspace"
-        ],
-        "summary": "Cancel invitation",
-        "description": "OWNER/ADMIN only. Cancels a pending invitation.",
-        "operationId": "cancel_workspace_invitation_api_v1_workspaces__workspace_slug__invitations__invitation_id__delete",
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "workspace_slug",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Workspace slug",
-              "title": "Workspace Slug"
-            },
-            "description": "Workspace slug"
-          },
-          {
-            "name": "invitation_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "description": "Invitation ID",
-              "title": "Invitation Id"
-            },
-            "description": "Invitation ID"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Invitation cancelled",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "400": {
-            "description": "Cancellation failed"
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "403": {
-            "description": "OWNER/ADMIN only"
-          },
-          "404": {
-            "description": "Workspace or invitation not found"
-          },
-          "500": {
-            "description": "Database error"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/workspaces/{workspace_slug}/members": {
-      "get": {
-        "tags": [
-          "Workspace"
-        ],
-        "summary": "List workspace members",
-        "description": "All workspace members can view. Returns paginated member list.",
-        "operationId": "list_workspace_members_api_v1_workspaces__workspace_slug__members_get",
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "workspace_slug",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Workspace slug",
-              "title": "Workspace Slug"
-            },
-            "description": "Workspace slug"
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "description": "Page number",
-              "default": 1,
-              "title": "Page"
-            },
-            "description": "Page number"
-          },
-          {
-            "name": "page_size",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "description": "Items per page",
-              "default": 30,
-              "title": "Page Size"
-            },
-            "description": "Items per page"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Member list",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/teehouse__api__routes__workspace_members__PaginatedTeamMembers"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "403": {
-            "description": "No workspace access"
-          },
-          "404": {
-            "description": "Workspace not found"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/workspaces/{workspace_slug}/members/{user_id}": {
-      "delete": {
-        "tags": [
-          "Workspace"
-        ],
-        "summary": "Remove workspace member",
-        "description": "OWNER/ADMIN only. Removes member and revokes their workspace API tokens.",
-        "operationId": "remove_workspace_member_api_v1_workspaces__workspace_slug__members__user_id__delete",
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "workspace_slug",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Workspace slug",
-              "title": "Workspace Slug"
-            },
-            "description": "Workspace slug"
-          },
-          {
-            "name": "user_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "User hashid to remove",
-              "title": "User Id"
-            },
-            "description": "User hashid to remove"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Member removed",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "400": {
-            "description": "Cannot remove workspace creator"
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "403": {
-            "description": "OWNER/ADMIN only"
-          },
-          "404": {
-            "description": "Workspace or member not found"
           },
           "422": {
             "description": "Validation Error",
@@ -9316,75 +5642,26 @@
           }
         }
       },
-      "patch": {
+      "delete": {
         "tags": [
-          "Workspace"
+          "Webhooks"
         ],
-        "summary": "Update member role",
-        "description": "OWNER only. Changes member role to ADMIN or MEMBER. Cannot change creator.",
-        "operationId": "update_member_role_api_v1_workspaces__workspace_slug__members__user_id__patch",
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ],
+        "summary": "Delete webhook",
+        "operationId": "delete_webhook_api_v1_workspace_webhooks__webhook_id__delete",
         "parameters": [
           {
-            "name": "workspace_slug",
+            "name": "webhook_id",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "description": "Workspace slug",
-              "title": "Workspace Slug"
-            },
-            "description": "Workspace slug"
-          },
-          {
-            "name": "user_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "User hashid to update",
-              "title": "User Id"
-            },
-            "description": "User hashid to update"
+              "title": "Webhook Id"
+            }
           }
         ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MemberRoleUpdateRequest"
-              }
-            }
-          }
-        },
         "responses": {
-          "200": {
-            "description": "Role updated",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid role or cannot modify creator"
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "403": {
-            "description": "OWNER only"
-          },
-          "404": {
-            "description": "Workspace or member not found"
+          "204": {
+            "description": "Successful Response"
           },
           "422": {
             "description": "Validation Error",
@@ -9399,14 +5676,13 @@
         }
       }
     },
-    "/api/v1/workspaces/{workspace_slug}/leave": {
+    "/api/v1/workspace/webhooks/{webhook_id}/reveal-secret": {
       "post": {
         "tags": [
-          "Workspace"
+          "Webhooks"
         ],
-        "summary": "Leave workspace",
-        "description": "Self-remove from workspace. Revokes your workspace API tokens. Creators cannot leave.",
-        "operationId": "leave_workspace_api_v1_workspaces__workspace_slug__leave_post",
+        "summary": "Reveal webhook secret (requires 2FA)",
+        "operationId": "reveal_webhook_secret_api_v1_workspace_webhooks__webhook_id__reveal_secret_post",
         "security": [
           {
             "OAuth2AuthorizationCodeBearer": []
@@ -9417,37 +5693,268 @@
         ],
         "parameters": [
           {
-            "name": "workspace_slug",
+            "name": "webhook_id",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "description": "Workspace slug",
-              "title": "Workspace Slug"
-            },
-            "description": "Workspace slug"
+              "title": "Webhook Id"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "Left workspace",
+            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {}
               }
             }
           },
-          "400": {
-            "description": "Creator cannot leave"
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workspace/webhooks/{webhook_id}/rotate-secret": {
+      "post": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Rotate webhook secret (requires 2FA)",
+        "operationId": "rotate_webhook_secret_api_v1_workspace_webhooks__webhook_id__rotate_secret_post",
+        "security": [
+          {
+            "OAuth2AuthorizationCodeBearer": []
           },
-          "401": {
-            "description": "Not authenticated"
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "webhook_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Webhook Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
-          "403": {
-            "description": "No workspace access"
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workspace/webhooks/{webhook_id}/test": {
+      "post": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Send test webhook event",
+        "operationId": "test_webhook_api_v1_workspace_webhooks__webhook_id__test_post",
+        "parameters": [
+          {
+            "name": "webhook_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Webhook Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
-          "404": {
-            "description": "Workspace not found or not a member"
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workspace/webhooks/{webhook_id}/deliveries": {
+      "get": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "List webhook deliveries",
+        "operationId": "list_deliveries_api_v1_workspace_webhooks__webhook_id__deliveries_get",
+        "parameters": [
+          {
+            "name": "webhook_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Webhook Id"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WebhookDeliveryResponse"
+                  },
+                  "title": "Response List Deliveries Api V1 Workspace Webhooks  Webhook Id  Deliveries Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workspace/webhooks/{webhook_id}/deliveries/{event_id}/resend": {
+      "post": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Resend a webhook delivery",
+        "operationId": "resend_delivery_api_v1_workspace_webhooks__webhook_id__deliveries__event_id__resend_post",
+        "parameters": [
+          {
+            "name": "webhook_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Webhook Id"
+            }
+          },
+          {
+            "name": "event_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Event Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workspace/webhooks/{webhook_id}/stats": {
+      "get": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Get webhook delivery stats",
+        "operationId": "webhook_stats_api_v1_workspace_webhooks__webhook_id__stats_get",
+        "parameters": [
+          {
+            "name": "webhook_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Webhook Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookStatsResponse"
+                }
+              }
+            }
           },
           "422": {
             "description": "Validation Error",
@@ -9656,921 +6163,6 @@
           },
           "401": {
             "description": "Not authenticated"
-          }
-        }
-      }
-    },
-    "/api/v1/profiles/me": {
-      "get": {
-        "tags": [
-          "Profiles"
-        ],
-        "summary": "Get current user profile",
-        "description": "Returns the authenticated user's profile. Returns null if no profile exists.",
-        "operationId": "get_my_profile_api_v1_profiles_me_get",
-        "responses": {
-          "200": {
-            "description": "Profile data or null",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/ProfileGetResponse"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "title": "Response Get My Profile Api V1 Profiles Me Get"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Not authenticated"
-          }
-        },
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ]
-      },
-      "put": {
-        "tags": [
-          "Profiles"
-        ],
-        "summary": "Update current user profile",
-        "description": "Accepts JSON body. custom_domain rejected for user profiles.",
-        "operationId": "update_my_profile_api_v1_profiles_me_put",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ProfileUpdateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Updated profile",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfileGetResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "custom_domain not allowed for user profiles"
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ]
-      }
-    },
-    "/api/v1/profiles/me/avatar": {
-      "put": {
-        "tags": [
-          "Profiles"
-        ],
-        "summary": "Upload avatar for current user",
-        "description": "Multipart file upload. Avatar max 5MB (jpeg/png/gif/webp).",
-        "operationId": "upload_my_avatar_api_v1_profiles_me_avatar_put",
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_upload_my_avatar_api_v1_profiles_me_avatar_put"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Updated profile with new avatar",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfileGetResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid file type"
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "413": {
-            "description": "File exceeds 5MB limit"
-          },
-          "500": {
-            "description": "Avatar upload failed"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ]
-      },
-      "delete": {
-        "tags": [
-          "Profiles"
-        ],
-        "summary": "Remove avatar for current user",
-        "description": "Remove avatar for the authenticated user.",
-        "operationId": "delete_my_avatar_api_v1_profiles_me_avatar_delete",
-        "responses": {
-          "200": {
-            "description": "Updated profile with avatar removed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfileGetResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Not authenticated"
-          }
-        },
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ]
-      }
-    },
-    "/api/v1/profiles/{entity_type}/{entity_id}": {
-      "get": {
-        "tags": [
-          "Profiles"
-        ],
-        "summary": "Get entity profile",
-        "description": "Public endpoint. Returns profile for any entity type. Accepts hashids (wks_xxx, prj_xxx) or integers.",
-        "operationId": "get_profile_api_v1_profiles__entity_type___entity_id__get",
-        "parameters": [
-          {
-            "name": "entity_type",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "enum": [
-                "user",
-                "workspace",
-                "app"
-              ],
-              "type": "string",
-              "description": "Entity type: user, workspace, or app",
-              "title": "Entity Type"
-            },
-            "description": "Entity type: user, workspace, or app"
-          },
-          {
-            "name": "entity_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Entity ID (hashid or integer)",
-              "title": "Entity Id"
-            },
-            "description": "Entity ID (hashid or integer)"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Profile data or null",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/ProfileGetResponse"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "title": "Response Get Profile Api V1 Profiles  Entity Type   Entity Id  Get"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid entity ID format"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "Profiles"
-        ],
-        "summary": "Update entity profile",
-        "description": "Accepts JSON body. Requires permission: own profile for users, OWNER/ADMIN for workspaces, any member for apps. custom_domain only for apps.",
-        "operationId": "update_profile_api_v1_profiles__entity_type___entity_id__put",
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "entity_type",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "enum": [
-                "user",
-                "workspace",
-                "app"
-              ],
-              "type": "string",
-              "description": "Entity type: user, workspace, or app",
-              "title": "Entity Type"
-            },
-            "description": "Entity type: user, workspace, or app"
-          },
-          {
-            "name": "entity_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Entity ID (hashid or integer)",
-              "title": "Entity Id"
-            },
-            "description": "Entity ID (hashid or integer)"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ProfileUpdateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Updated profile",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfileGetResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid ID format or custom_domain on wrong entity type"
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "403": {
-            "description": "No permission to edit this profile"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Profiles"
-        ],
-        "summary": "Delete entity profile",
-        "description": "Requires permission: own profile for users, OWNER/ADMIN for workspaces, any member for apps.",
-        "operationId": "delete_profile_api_v1_profiles__entity_type___entity_id__delete",
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "entity_type",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "enum": [
-                "user",
-                "workspace",
-                "app"
-              ],
-              "type": "string",
-              "description": "Entity type: user, workspace, or app",
-              "title": "Entity Type"
-            },
-            "description": "Entity type: user, workspace, or app"
-          },
-          {
-            "name": "entity_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Entity ID (hashid or integer)",
-              "title": "Entity Id"
-            },
-            "description": "Entity ID (hashid or integer)"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Profile deleted",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid entity ID format"
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "403": {
-            "description": "No permission to delete this profile"
-          },
-          "404": {
-            "description": "Profile not found"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/profiles/{entity_type}/{entity_id}/avatar": {
-      "put": {
-        "tags": [
-          "Profiles"
-        ],
-        "summary": "Upload avatar for entity",
-        "description": "Multipart file upload. Avatar max 5MB (jpeg/png/gif/webp).",
-        "operationId": "upload_avatar_api_v1_profiles__entity_type___entity_id__avatar_put",
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "entity_type",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "enum": [
-                "user",
-                "workspace",
-                "app"
-              ],
-              "type": "string",
-              "description": "Entity type: user, workspace, or app",
-              "title": "Entity Type"
-            },
-            "description": "Entity type: user, workspace, or app"
-          },
-          {
-            "name": "entity_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Entity ID (hashid or integer)",
-              "title": "Entity Id"
-            },
-            "description": "Entity ID (hashid or integer)"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_upload_avatar_api_v1_profiles__entity_type___entity_id__avatar_put"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Updated profile with new avatar",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfileGetResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid file type or entity ID"
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "403": {
-            "description": "No permission"
-          },
-          "413": {
-            "description": "File exceeds 5MB limit"
-          },
-          "500": {
-            "description": "Avatar upload failed"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Profiles"
-        ],
-        "summary": "Remove avatar for entity",
-        "description": "Remove avatar for a user, workspace, or app.",
-        "operationId": "delete_avatar_api_v1_profiles__entity_type___entity_id__avatar_delete",
-        "security": [
-          {
-            "OAuth2AuthorizationCodeBearer": []
-          },
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "entity_type",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "enum": [
-                "user",
-                "workspace",
-                "app"
-              ],
-              "type": "string",
-              "description": "Entity type: user, workspace, or app",
-              "title": "Entity Type"
-            },
-            "description": "Entity type: user, workspace, or app"
-          },
-          {
-            "name": "entity_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Entity ID (hashid or integer)",
-              "title": "Entity Id"
-            },
-            "description": "Entity ID (hashid or integer)"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Updated profile with avatar removed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfileGetResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid entity ID"
-          },
-          "401": {
-            "description": "Not authenticated"
-          },
-          "403": {
-            "description": "No permission"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/usage/current": {
-      "get": {
-        "tags": [
-          "Usage"
-        ],
-        "summary": "Get current usage status",
-        "description": "Returns running CVM count with cost forecast for today and the month.",
-        "operationId": "get_current_status_api_v1_usage_current_get",
-        "responses": {
-          "200": {
-            "description": "Current usage status with forecasts",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CurrentStatusResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required"
-          }
-        }
-      }
-    },
-    "/api/v1/usage/data": {
-      "get": {
-        "tags": [
-          "Usage"
-        ],
-        "summary": "Get usage data",
-        "description": "Returns metered usage for the specified period: core metrics, daily trends, instance type breakdown, and per-CVM details.",
-        "operationId": "get_usage_data_api_v1_usage_data_get",
-        "parameters": [
-          {
-            "name": "range_type",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "enum": [
-                "today",
-                "week",
-                "month",
-                "quarter",
-                "custom"
-              ],
-              "type": "string",
-              "description": "Time range preset",
-              "default": "month",
-              "title": "Range Type"
-            },
-            "description": "Time range preset"
-          },
-          {
-            "name": "custom_start",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Start date for custom range (YYYY-MM-DD)",
-              "title": "Custom Start"
-            },
-            "description": "Start date for custom range (YYYY-MM-DD)"
-          },
-          {
-            "name": "custom_end",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "End date for custom range (YYYY-MM-DD)",
-              "title": "Custom End"
-            },
-            "description": "End date for custom range (YYYY-MM-DD)"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Usage data with metrics and breakdown",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UsageDataResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid range_type or custom date range"
-          },
-          "401": {
-            "description": "Authentication required"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/usage/export": {
-      "get": {
-        "tags": [
-          "Usage"
-        ],
-        "summary": "Export usage data",
-        "description": "Downloads usage report as CSV (zipped), Excel, or PDF file.",
-        "operationId": "export_usage_data_api_v1_usage_export_get",
-        "parameters": [
-          {
-            "name": "format",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "enum": [
-                "csv",
-                "xlsx",
-                "pdf"
-              ],
-              "type": "string",
-              "description": "Export format: csv (zipped), xlsx, or pdf",
-              "default": "csv",
-              "title": "Format"
-            },
-            "description": "Export format: csv (zipped), xlsx, or pdf"
-          },
-          {
-            "name": "range_type",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "enum": [
-                "today",
-                "week",
-                "month",
-                "quarter",
-                "custom"
-              ],
-              "type": "string",
-              "description": "Time range preset",
-              "default": "month",
-              "title": "Range Type"
-            },
-            "description": "Time range preset"
-          },
-          {
-            "name": "custom_start",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Start date for custom range (YYYY-MM-DD)",
-              "title": "Custom Start"
-            },
-            "description": "Start date for custom range (YYYY-MM-DD)"
-          },
-          {
-            "name": "custom_end",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "End date for custom range (YYYY-MM-DD)",
-              "title": "Custom End"
-            },
-            "description": "End date for custom range (YYYY-MM-DD)"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "File download",
-            "content": {
-              "application/json": {
-                "schema": {}
-              },
-              "application/zip": {},
-              "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": {},
-              "application/pdf": {}
-            }
-          },
-          "400": {
-            "description": "Invalid range_type or custom date range"
-          },
-          "401": {
-            "description": "Authentication required"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/gpus/reserved": {
-      "get": {
-        "tags": [
-          "GPUs"
-        ],
-        "summary": "List reserved GPUs",
-        "description": "Returns all GPUs reserved for the workspace with their current mode and usage status. Queries each node via Teescope for live status.",
-        "operationId": "list_reserved_gpus_api_v1_gpus_reserved_get",
-        "responses": {
-          "200": {
-            "description": "List of reserved GPUs with status",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListReservedGpusResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required"
-          }
-        }
-      }
-    },
-    "/api/v1/gpus/switch-mode": {
-      "post": {
-        "tags": [
-          "GPUs"
-        ],
-        "summary": "Switch GPU mode",
-        "description": "Changes CC/PPCIe mode for reserved GPUs. All GPUs must be on the same node and idle (no attached VMs or VFIO processes).",
-        "operationId": "switch_gpus_mode_api_v1_gpus_switch_mode_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SwitchGpusModeRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Mode switch completed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SwitchGpusModeResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "GPUs on different nodes or node missing API endpoint"
-          },
-          "401": {
-            "description": "Authentication required"
-          },
-          "403": {
-            "description": "Workspace has no reserved GPUs or requested GPUs not reserved"
-          },
-          "404": {
-            "description": "One or more GPU IDs not found"
-          },
-          "409": {
-            "description": "GPUs are in use, cannot switch mode"
-          },
-          "503": {
-            "description": "Node unreachable or mode switch failed"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
           }
         }
       }
@@ -11173,6 +6765,35 @@
             "title": "Instance Id",
             "description": "VM UUID (instance_id)"
           },
+          "triggered_by": {
+            "type": "integer",
+            "title": "Triggered By",
+            "description": "User ID who triggered the event (0 = system)"
+          },
+          "triggered_by_username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Triggered By Username",
+            "description": "Username of the triggering user"
+          },
+          "triggered_by_email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Triggered By Email",
+            "description": "Email of the triggering user"
+          },
           "cvm": {
             "anyOf": [
               {
@@ -11218,7 +6839,8 @@
           "event_type",
           "status",
           "timestamp",
-          "instance_id"
+          "instance_id",
+          "triggered_by"
         ],
         "title": "AdminInstanceEventResponse",
         "description": "Instance lifecycle event with CVM, user, and team context."
@@ -11280,7 +6902,7 @@
             "description": "Last successful ping"
           },
           "capacity": {
-            "$ref": "#/components/schemas/teehouse__api__routes__admin__nodes__TeepodCapacity",
+            "$ref": "#/components/schemas/teehouse__api__routes__admin__nodes__schemas__TeepodCapacity",
             "description": "Resource capacity limits"
           },
           "resource_usage": {
@@ -11301,7 +6923,7 @@
           "node_resource_usage": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/teehouse__api__routes__admin__nodes__NodeResourceUsage"
+                "$ref": "#/components/schemas/teehouse__api__routes__admin__nodes__schemas__NodeResourceUsage"
               },
               {
                 "type": "null"
@@ -11817,6 +7439,122 @@
         "title": "AllFamiliesResponse",
         "description": "All instance type families with their types."
       },
+      "AllocationDetail": {
+        "properties": {
+          "cvm_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cvm Id"
+          },
+          "cvm_app_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cvm App Id"
+          },
+          "cvm_vm_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cvm Vm Uuid"
+          },
+          "cvm_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cvm Status"
+          },
+          "node_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Node Name"
+          },
+          "teepod_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Teepod Name"
+          },
+          "gpus": {
+            "items": {
+              "$ref": "#/components/schemas/AllocationGpuDetail"
+            },
+            "type": "array",
+            "title": "Gpus"
+          },
+          "allocated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allocated At"
+          }
+        },
+        "type": "object",
+        "title": "AllocationDetail",
+        "description": "CVM allocation detail for an order."
+      },
+      "AllocationGpuDetail": {
+        "properties": {
+          "gpu_id": {
+            "type": "integer",
+            "title": "Gpu Id"
+          },
+          "product_id": {
+            "type": "string",
+            "title": "Product Id"
+          },
+          "slot": {
+            "type": "string",
+            "title": "Slot"
+          }
+        },
+        "type": "object",
+        "required": [
+          "gpu_id",
+          "product_id",
+          "slot"
+        ],
+        "title": "AllocationGpuDetail",
+        "description": "GPU details for an allocation."
+      },
       "AllocationHistoryItem": {
         "properties": {
           "cvm_id": {
@@ -12205,6 +7943,8 @@
         "properties": {
           "name": {
             "type": "string",
+            "maxLength": 100,
+            "minLength": 1,
             "title": "Name"
           },
           "expires_in_days": {
@@ -12604,6 +8344,95 @@
           "is_allowed"
         ],
         "title": "AppIsAllowedResponse"
+      },
+      "AppKmsInfoResponse": {
+        "properties": {
+          "is_onchain_kms": {
+            "type": "boolean",
+            "title": "Is Onchain Kms",
+            "default": false
+          },
+          "chain_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chain Id"
+          },
+          "kms_contract_address": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Kms Contract Address"
+          },
+          "app_contract_address": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "App Contract Address"
+          },
+          "deployer_address": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deployer Address"
+          },
+          "deployer_type": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "eoa",
+                  "safe",
+                  "legacy_multisig",
+                  "erc4337",
+                  "contract"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deployer Type"
+          },
+          "is_contract": {
+            "type": "boolean",
+            "title": "Is Contract",
+            "default": false
+          },
+          "safe_app_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Safe App Url"
+          }
+        },
+        "type": "object",
+        "title": "AppKmsInfoResponse"
       },
       "AppRevisionDetailResponse": {
         "properties": {
@@ -14576,9 +10405,97 @@
               }
             ],
             "title": "Stripe Customer Email"
+          },
+          "billing_mode": {
+            "type": "string",
+            "enum": [
+              "prepaid",
+              "prepaid_auto_topup",
+              "post_paid"
+            ],
+            "title": "Billing Mode"
+          },
+          "flag_billing_v2_enabled": {
+            "type": "boolean",
+            "title": "Flag Billing V2 Enabled"
+          },
+          "auto_topup_enabled": {
+            "type": "boolean",
+            "title": "Auto Topup Enabled"
+          },
+          "auto_topup_amount": {
+            "type": "string",
+            "format": "decimal",
+            "title": "Auto Topup Amount",
+            "description": "A monetary value with precise decimal arithmetic",
+            "examples": [
+              "19.99",
+              "123.456000"
+            ]
+          },
+          "auto_topup_threshold": {
+            "type": "string",
+            "format": "decimal",
+            "title": "Auto Topup Threshold",
+            "description": "A monetary value with precise decimal arithmetic",
+            "examples": [
+              "19.99",
+              "123.456000"
+            ]
+          },
+          "post_paid_available": {
+            "type": "boolean",
+            "title": "Post Paid Available"
+          },
+          "post_paid_charge_cap": {
+            "type": "string",
+            "format": "decimal",
+            "title": "Post Paid Charge Cap",
+            "description": "A monetary value with precise decimal arithmetic",
+            "examples": [
+              "19.99",
+              "123.456000"
+            ]
+          },
+          "post_paid_grace_deadline": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Post Paid Grace Deadline"
+          },
+          "has_saved_card": {
+            "type": "boolean",
+            "title": "Has Saved Card"
+          },
+          "outstanding_debt": {
+            "type": "string",
+            "format": "decimal",
+            "title": "Outstanding Debt",
+            "description": "A monetary value with precise decimal arithmetic",
+            "default": "0.000000",
+            "examples": [
+              "19.99",
+              "123.456000"
+            ]
           }
         },
         "type": "object",
+        "required": [
+          "billing_mode",
+          "flag_billing_v2_enabled",
+          "auto_topup_enabled",
+          "auto_topup_amount",
+          "auto_topup_threshold",
+          "post_paid_available",
+          "post_paid_charge_cap",
+          "has_saved_card"
+        ],
         "title": "BillingSettingsResponse"
       },
       "BlacklistRequest": {
@@ -15912,38 +11829,6 @@
         ],
         "title": "CIOTriggerBroadcastResponse"
       },
-      "CPUQuantity": {
-        "properties": {
-          "value": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "string"
-              },
-              {
-                "type": "integer"
-              }
-            ],
-            "title": "Value"
-          },
-          "suffix": {
-            "type": "string",
-            "enum": [
-              "m",
-              ""
-            ],
-            "title": "Suffix",
-            "default": ""
-          }
-        },
-        "type": "object",
-        "required": [
-          "value"
-        ],
-        "title": "CPUQuantity"
-      },
       "CVMDetail": {
         "properties": {
           "cvm_id": {
@@ -16222,6 +12107,11 @@
             "type": "string",
             "title": "Status"
           },
+          "in_progress": {
+            "type": "boolean",
+            "title": "In Progress",
+            "default": false
+          },
           "progress": {
             "anyOf": [
               {
@@ -16267,6 +12157,9 @@
           },
           "gateway": {
             "$ref": "#/components/schemas/CVMGatewayInfo"
+          },
+          "logs": {
+            "$ref": "#/components/schemas/CVMLogUrls"
           },
           "services": {
             "items": {
@@ -16578,6 +12471,56 @@
         "type": "object",
         "title": "CVMKmsInfo"
       },
+      "CVMLogUrls": {
+        "properties": {
+          "serial": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Serial"
+          },
+          "stdout": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stdout"
+          },
+          "stderr": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stderr"
+          },
+          "container_log_base": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Container Log Base"
+          }
+        },
+        "type": "object",
+        "title": "CVMLogUrls"
+      },
       "CVMOSInfo": {
         "properties": {
           "name": {
@@ -16888,6 +12831,33 @@
         ],
         "title": "CaaCheckResult",
         "description": "CAA record check result (informational, not required for validation)."
+      },
+      "CancelOperationRequest": {
+        "properties": {
+          "cancelled": {
+            "type": "boolean",
+            "title": "Cancelled",
+            "description": "Whether an operation was actually cancelled"
+          },
+          "correlation_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Correlation Id",
+            "description": "Correlation ID of the cancelled op"
+          }
+        },
+        "type": "object",
+        "required": [
+          "cancelled"
+        ],
+        "title": "CancelOperationRequest",
+        "description": "Response for cancel operation."
       },
       "CancelOperationResponse": {
         "properties": {
@@ -17431,6 +13401,12 @@
             ],
             "title": "Invoice Id",
             "description": "Invoice ID for direct invoice payment"
+          },
+          "force_checkout": {
+            "type": "boolean",
+            "title": "Force Checkout",
+            "description": "For Stripe only: skip direct card charge and always create checkout session",
+            "default": false
           }
         },
         "type": "object",
@@ -17772,6 +13748,11 @@
                 "type": "null"
               }
             ]
+          },
+          "compose_hash_registered": {
+            "type": "boolean",
+            "title": "Compose Hash Registered",
+            "default": false
           }
         },
         "type": "object",
@@ -18170,110 +14151,6 @@
         ],
         "title": "ConnectionListResponse"
       },
-      "Container": {
-        "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "image": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "$ref": "#/components/schemas/ImageSpec"
-              }
-            ],
-            "title": "Image"
-          },
-          "resources": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ResourceRequirements"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "ports": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/ContainerPort"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Ports"
-          }
-        },
-        "type": "object",
-        "required": [
-          "name",
-          "image"
-        ],
-        "title": "Container"
-      },
-      "ContainerPort": {
-        "properties": {
-          "containerPort": {
-            "type": "integer",
-            "maximum": 65535.0,
-            "minimum": 1.0,
-            "title": "Containerport"
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          },
-          "hostPort": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "maximum": 65535.0,
-                "minimum": 1.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Hostport"
-          },
-          "protocol": {
-            "$ref": "#/components/schemas/Protocol",
-            "default": "TCP"
-          },
-          "hostIP": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Hostip"
-          }
-        },
-        "type": "object",
-        "required": [
-          "containerPort"
-        ],
-        "title": "ContainerPort",
-        "description": "ContainerPort represents a network port in a single container.\nRef: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#containerport-v1-core"
-      },
       "ContractDeviceOut": {
         "properties": {
           "device_id": {
@@ -18480,6 +14357,109 @@
         ],
         "title": "CoreMetrics",
         "description": "Core usage metrics."
+      },
+      "CreateAppInstanceRequest": {
+        "properties": {
+          "teepod_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Teepod Id",
+            "description": "Target node ID (deprecated, use node_id)"
+          },
+          "node_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Node Id",
+            "description": "Target node ID for the replica"
+          },
+          "encrypted_env": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Encrypted Env",
+            "description": "New encrypted env blob (hex)"
+          },
+          "compose_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Compose Hash",
+            "description": "Explicit compose hash to replicate. Required when the source app has multiple live instances."
+          },
+          "docker_compose_file": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Docker Compose File",
+            "description": "New Docker Compose YAML content"
+          },
+          "pre_launch_script": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pre Launch Script",
+            "description": "New pre-launch script content"
+          },
+          "token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Token",
+            "description": "Commit token returned by a prior prepare-only request. When set, this request commits the previously-prepared instance instead of preparing a new one."
+          },
+          "transaction_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Transaction Hash",
+            "description": "On-chain transaction hash proving compose-hash registration. Use 'already-registered' (or omit) when the hash was registered earlier."
+          }
+        },
+        "type": "object",
+        "title": "CreateAppInstanceRequest",
+        "description": "Request model for creating a new instance under an existing app.\n\nInherits node_id, encrypted_env, compose_hash and their validators from ReplicateRequest."
       },
       "CreateConnectionRequest": {
         "properties": {
@@ -20491,6 +16471,24 @@
             ],
             "title": "Boot Error"
           },
+          "shutdown_progress": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shutdown Progress"
+          },
+          "events": {
+            "items": {
+              "$ref": "#/components/schemas/GuestEvent"
+            },
+            "type": "array",
+            "title": "Events"
+          },
           "operation_type": {
             "anyOf": [
               {
@@ -20610,6 +16608,241 @@
           "is_online"
         ],
         "title": "CvmSystemInfo"
+      },
+      "CvmTeescopeEgress": {
+        "properties": {
+          "total_sent_bytes": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Total Sent Bytes",
+            "default": 0
+          },
+          "total_recv_bytes": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Total Recv Bytes",
+            "default": 0
+          },
+          "peak_sent_kbs": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Peak Sent Kbs",
+            "default": 0.0
+          },
+          "peak_recv_kbs": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Peak Recv Kbs",
+            "default": 0.0
+          }
+        },
+        "type": "object",
+        "title": "CvmTeescopeEgress"
+      },
+      "CvmTeescopeInfo": {
+        "properties": {
+          "vm_uuid": {
+            "type": "string",
+            "title": "Vm Uuid"
+          },
+          "qemu": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CvmTeescopeQemu"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "storage": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CvmTeescopeStorage"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "egress": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CvmTeescopeEgress"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "ingress": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CvmTeescopeIngress"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "vm_uuid"
+        ],
+        "title": "CvmTeescopeInfo"
+      },
+      "CvmTeescopeIngress": {
+        "properties": {
+          "app_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "App Id"
+          },
+          "total_bytes": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Total Bytes",
+            "default": 0
+          },
+          "connections": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Connections",
+            "default": 0
+          },
+          "snis": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Snis"
+          }
+        },
+        "type": "object",
+        "title": "CvmTeescopeIngress"
+      },
+      "CvmTeescopeQemu": {
+        "properties": {
+          "pid": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Pid"
+          },
+          "uptime": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Uptime",
+            "default": 0
+          },
+          "cpu_usage_perc": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Cpu Usage Perc",
+            "default": 0.0
+          },
+          "cpu_pct_usr": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Cpu Pct Usr",
+            "default": 0.0
+          },
+          "cpu_pct_system": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Cpu Pct System",
+            "default": 0.0
+          },
+          "cpu_pct_guest": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Cpu Pct Guest",
+            "default": 0.0
+          },
+          "cpu_pct_wait": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Cpu Pct Wait",
+            "default": 0.0
+          },
+          "cpu_pct_total": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Cpu Pct Total",
+            "default": 0.0
+          },
+          "cpu_cores": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Cpu Cores",
+            "default": 0
+          },
+          "allocated_mb": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Allocated Mb",
+            "default": 0
+          },
+          "kvm_guest_mem_mb": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Kvm Guest Mem Mb",
+            "default": 0.0
+          },
+          "kvm_mem_usage_perc": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Kvm Mem Usage Perc",
+            "default": 0.0
+          },
+          "io_read_bytes": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Io Read Bytes",
+            "default": 0
+          },
+          "io_write_bytes": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Io Write Bytes",
+            "default": 0
+          },
+          "slots": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Slots"
+          }
+        },
+        "type": "object",
+        "required": [
+          "pid"
+        ],
+        "title": "CvmTeescopeQemu"
+      },
+      "CvmTeescopeStorage": {
+        "properties": {
+          "size_bytes": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Size Bytes",
+            "default": 0
+          },
+          "exists": {
+            "type": "boolean",
+            "title": "Exists",
+            "default": false
+          }
+        },
+        "type": "object",
+        "title": "CvmTeescopeStorage"
       },
       "CvmUpgradePayload": {
         "properties": {
@@ -20985,6 +17218,119 @@
         ],
         "title": "DailyUsageItem",
         "description": "Daily usage item with compute and disk costs."
+      },
+      "DecoupleOrderRequest": {
+        "properties": {
+          "reason": {
+            "type": "string",
+            "maxLength": 500,
+            "minLength": 1,
+            "title": "Reason",
+            "description": "Short justification recorded in logs and returned to the caller"
+          },
+          "internal_note": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 2000
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Internal Note",
+            "description": "Optional extended audit note, not user-visible"
+          },
+          "target_billing_period": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BillingPeriod"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Explicit billing period for the detached CVMs. Defaults to HOURLY for regular tiers and SKIP for enterprise tiers."
+          }
+        },
+        "type": "object",
+        "required": [
+          "reason"
+        ],
+        "title": "DecoupleOrderRequest",
+        "description": "Input for decoupling a GPU rental order."
+      },
+      "DecoupleOrderResponse": {
+        "properties": {
+          "order_id": {
+            "type": "string",
+            "format": "hashid",
+            "title": "Order Id",
+            "description": "A hashed identifier that maps to an internal database ID",
+            "examples": [
+              "0123abcd"
+            ]
+          },
+          "status": {
+            "$ref": "#/components/schemas/GpuRentalOrderStatus"
+          },
+          "previous_status": {
+            "$ref": "#/components/schemas/GpuRentalOrderStatus"
+          },
+          "decoupled_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Decoupled At"
+          },
+          "target_billing_period": {
+            "$ref": "#/components/schemas/BillingPeriod"
+          },
+          "affected_cvms": {
+            "items": {
+              "$ref": "#/components/schemas/DecoupledCvmChangeOut"
+            },
+            "type": "array",
+            "title": "Affected Cvms"
+          }
+        },
+        "type": "object",
+        "required": [
+          "order_id",
+          "status",
+          "previous_status",
+          "decoupled_at",
+          "target_billing_period",
+          "affected_cvms"
+        ],
+        "title": "DecoupleOrderResponse"
+      },
+      "DecoupledCvmChangeOut": {
+        "properties": {
+          "cvm_id": {
+            "type": "integer",
+            "title": "Cvm Id"
+          },
+          "previous_billing_period": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BillingPeriod"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "new_billing_period": {
+            "$ref": "#/components/schemas/BillingPeriod"
+          }
+        },
+        "type": "object",
+        "required": [
+          "cvm_id",
+          "previous_billing_period",
+          "new_billing_period"
+        ],
+        "title": "DecoupledCvmChangeOut"
       },
       "DeviceAllowlistItem": {
         "properties": {
@@ -21393,41 +17739,104 @@
         ],
         "title": "DiskInfo"
       },
-      "DiskQuantity": {
+      "DisputeOperation": {
         "properties": {
-          "value": {
+          "cvm_id": {
+            "type": "integer",
+            "title": "Cvm Id"
+          },
+          "cvm_name": {
+            "type": "string",
+            "title": "Cvm Name"
+          },
+          "instance_id": {
+            "type": "string",
+            "title": "Instance Id"
+          },
+          "operation": {
+            "type": "string",
+            "title": "Operation"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Timestamp"
+          },
+          "triggered_by": {
+            "type": "integer",
+            "title": "Triggered By"
+          },
+          "triggered_by_username": {
             "anyOf": [
               {
-                "type": "number"
+                "type": "string"
               },
               {
-                "type": "string"
+                "type": "null"
               }
             ],
-            "title": "Value"
+            "title": "Triggered By Username"
           },
-          "suffix": {
-            "type": "string",
-            "enum": [
-              "Ki",
-              "Mi",
-              "Gi",
-              "Ti",
-              "k",
-              "m",
-              "G",
-              "T",
-              ""
+          "running_duration_hours": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
             ],
-            "title": "Suffix",
-            "default": ""
+            "title": "Running Duration Hours"
           }
         },
         "type": "object",
         "required": [
-          "value"
+          "cvm_id",
+          "cvm_name",
+          "instance_id",
+          "operation",
+          "timestamp",
+          "triggered_by"
         ],
-        "title": "DiskQuantity"
+        "title": "DisputeOperation"
+      },
+      "DisputeTimelineResponse": {
+        "properties": {
+          "team_id": {
+            "type": "integer",
+            "title": "Team Id"
+          },
+          "team_name": {
+            "type": "string",
+            "title": "Team Name"
+          },
+          "period_start": {
+            "type": "string",
+            "format": "date",
+            "title": "Period Start"
+          },
+          "period_end": {
+            "type": "string",
+            "format": "date",
+            "title": "Period End"
+          },
+          "operations": {
+            "items": {
+              "$ref": "#/components/schemas/DisputeOperation"
+            },
+            "type": "array",
+            "title": "Operations"
+          }
+        },
+        "type": "object",
+        "required": [
+          "team_id",
+          "team_name",
+          "period_start",
+          "period_end",
+          "operations"
+        ],
+        "title": "DisputeTimelineResponse"
       },
       "DnsRecordResult": {
         "properties": {
@@ -22612,10 +19021,39 @@
         "title": "FinalizeInvoiceResponse",
         "description": "Response for finalize invoice operation."
       },
+      "FirewallStatusResponse": {
+        "properties": {
+          "available": {
+            "type": "boolean",
+            "title": "Available",
+            "description": "Whether firewall/port-mapping is available"
+          },
+          "reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reason",
+            "description": "Why it is unavailable"
+          }
+        },
+        "type": "object",
+        "required": [
+          "available"
+        ],
+        "title": "FirewallStatusResponse",
+        "description": "Firewall availability for the node hosting a CVM."
+      },
       "GithubProfileImportRequest": {
         "properties": {
           "github_username": {
             "type": "string",
+            "maxLength": 39,
+            "minLength": 1,
             "title": "Github Username",
             "description": "GitHub username to import SSH keys from"
           }
@@ -23454,6 +19892,136 @@
         "title": "GpuRentalOrderCreateResponse",
         "description": "Response payload for GPU rental order creation (minimal info)."
       },
+      "GpuRentalOrderHistoryItem": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^gord_.+",
+            "format": "hashid",
+            "title": "HashedId[gpu_rental_orders]",
+            "description": "A hashed identifier that maps to an internal database ID",
+            "examples": [
+              "gord_0123abcd"
+            ]
+          },
+          "status": {
+            "$ref": "#/components/schemas/GpuRentalOrderStatus"
+          },
+          "sku": {
+            "$ref": "#/components/schemas/GpuSkuHistoryResponse"
+          },
+          "quantity": {
+            "type": "integer",
+            "title": "Quantity"
+          },
+          "agreed_hourly_rate": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agreed Hourly Rate"
+          },
+          "total_spent": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Spent"
+          },
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          },
+          "activated_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Activated At"
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Completed At"
+          },
+          "cancelled_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cancelled At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "status",
+          "sku",
+          "quantity",
+          "created_at"
+        ],
+        "title": "GpuRentalOrderHistoryItem",
+        "description": "User-facing order history item. Does not expose admin-only decouple metadata."
+      },
+      "GpuRentalOrderHistoryResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/GpuRentalOrderHistoryItem"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "page": {
+            "type": "integer",
+            "title": "Page"
+          },
+          "page_size": {
+            "type": "integer",
+            "title": "Page Size"
+          },
+          "pages": {
+            "type": "integer",
+            "title": "Pages"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "total",
+          "page",
+          "page_size",
+          "pages"
+        ],
+        "title": "GpuRentalOrderHistoryResponse",
+        "description": "Paginated order history response."
+      },
       "GpuRentalOrderItem": {
         "properties": {
           "id": {
@@ -23591,6 +20159,30 @@
             ],
             "title": "Cancelled At"
           },
+          "decoupled_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Decoupled At"
+          },
+          "hourly_billing_start_time": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hourly Billing Start Time"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -23703,6 +20295,73 @@
             "type": "integer",
             "title": "Allocation Count",
             "default": 0
+          },
+          "allocations": {
+            "items": {
+              "$ref": "#/components/schemas/AllocationDetail"
+            },
+            "type": "array",
+            "title": "Allocations"
+          },
+          "decouple_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Decouple Reason"
+          },
+          "decouple_internal_note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Decouple Internal Note"
+          },
+          "decoupled_by_user_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "hashid",
+                "description": "A hashed identifier that maps to an internal database ID",
+                "examples": [
+                  "0123abcd"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Decoupled By User Id"
+          },
+          "decoupled_by_email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Decoupled By Email"
+          },
+          "decoupled_by_username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Decoupled By Username"
           }
         },
         "type": "object",
@@ -23722,6 +20381,8 @@
           "activated_at",
           "completed_at",
           "cancelled_at",
+          "decoupled_at",
+          "hourly_billing_start_time",
           "created_at",
           "updated_at"
         ],
@@ -23820,6 +20481,73 @@
         "title": "GpuRentalOrderStatus",
         "description": "Lifecycle states for GPU rental orders."
       },
+      "GpuRentalOrderSummaryOut": {
+        "properties": {
+          "order_id": {
+            "type": "string",
+            "format": "hashid",
+            "title": "Order Id",
+            "description": "A hashed identifier that maps to an internal database ID",
+            "examples": [
+              "0123abcd"
+            ]
+          },
+          "pricing_plan": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GpuSkuPricingPlan"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "commitment_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Commitment Days"
+          },
+          "financial": {
+            "$ref": "#/components/schemas/OrderFinancialSummaryOut"
+          },
+          "minimum_period": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OrderMinimumPeriodOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "runway": {
+            "$ref": "#/components/schemas/OrderRunwayOut"
+          },
+          "related_transactions": {
+            "items": {
+              "$ref": "#/components/schemas/RelatedTransactionOut"
+            },
+            "type": "array",
+            "title": "Related Transactions"
+          }
+        },
+        "type": "object",
+        "required": [
+          "order_id",
+          "pricing_plan",
+          "commitment_days",
+          "financial",
+          "minimum_period",
+          "runway"
+        ],
+        "title": "GpuRentalOrderSummaryOut"
+      },
       "GpuRentalProvisionRequest": {
         "properties": {
           "sku_id": {
@@ -23915,6 +20643,51 @@
         ],
         "title": "GpuReservedTeamInfo",
         "description": "Team with reserved access to GPU."
+      },
+      "GpuSkuAllowedTeamCreate": {
+        "properties": {
+          "team_id": {
+            "type": "string",
+            "title": "Team Id",
+            "description": "Team hashed ID (wks_xxx) to grant visibility to"
+          }
+        },
+        "type": "object",
+        "required": [
+          "team_id"
+        ],
+        "title": "GpuSkuAllowedTeamCreate",
+        "description": "Input for adding a team to a GPU SKU visibility allowlist."
+      },
+      "GpuSkuAllowedTeamsOut": {
+        "properties": {
+          "sku_id": {
+            "type": "integer",
+            "title": "Sku Id",
+            "description": "SKU ID"
+          },
+          "allowed_team_ids": {
+            "items": {
+              "type": "string",
+              "pattern": "^wks_.+",
+              "format": "hashid",
+              "title": "HashedId[teams]",
+              "description": "A hashed identifier that maps to an internal database ID",
+              "examples": [
+                "wks_0123abcd"
+              ]
+            },
+            "type": "array",
+            "title": "Allowed Team Ids",
+            "description": "Team IDs with access; empty list means the SKU is public"
+          }
+        },
+        "type": "object",
+        "required": [
+          "sku_id"
+        ],
+        "title": "GpuSkuAllowedTeamsOut",
+        "description": "Allowlist snapshot for a GPU SKU."
       },
       "GpuSkuCreate": {
         "properties": {
@@ -24041,6 +20814,18 @@
             "type": "object",
             "title": "Extra Specs"
           },
+          "instance_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instance Type",
+            "description": "Instance type ID for CVM provisioning"
+          },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
@@ -24058,6 +20843,30 @@
           "min_rental_duration_hours"
         ],
         "title": "GpuSkuCreate"
+      },
+      "GpuSkuHistoryResponse": {
+        "properties": {
+          "display_name": {
+            "type": "string",
+            "title": "Display Name"
+          },
+          "gpu_count": {
+            "type": "integer",
+            "title": "Gpu Count"
+          },
+          "gpu_model": {
+            "type": "string",
+            "title": "Gpu Model"
+          }
+        },
+        "type": "object",
+        "required": [
+          "display_name",
+          "gpu_count",
+          "gpu_model"
+        ],
+        "title": "GpuSkuHistoryResponse",
+        "description": "Minimal SKU info for order history."
       },
       "GpuSkuOut": {
         "properties": {
@@ -24184,6 +20993,18 @@
             "title": "Extra Specs",
             "description": "Additional specifications"
           },
+          "instance_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instance Type",
+            "description": "Instance type ID for CVM provisioning"
+          },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
@@ -24208,6 +21029,21 @@
             "type": "array",
             "title": "Prices",
             "description": "Pricing tiers"
+          },
+          "allowed_team_ids": {
+            "items": {
+              "type": "string",
+              "pattern": "^wks_.+",
+              "format": "hashid",
+              "title": "HashedId[teams]",
+              "description": "A hashed identifier that maps to an internal database ID",
+              "examples": [
+                "wks_0123abcd"
+              ]
+            },
+            "type": "array",
+            "title": "Allowed Team Ids",
+            "description": "Team allowlist. Empty list means the SKU is public; any entry restricts visibility to the listed teams."
           }
         },
         "type": "object",
@@ -24697,6 +21533,17 @@
             ],
             "title": "Extra Specs"
           },
+          "instance_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instance Type"
+          },
           "is_active": {
             "anyOf": [
               {
@@ -24946,6 +21793,30 @@
         ],
         "title": "GuestAgentInfo"
       },
+      "GuestEvent": {
+        "properties": {
+          "event": {
+            "type": "string",
+            "title": "Event"
+          },
+          "body": {
+            "type": "string",
+            "title": "Body"
+          },
+          "timestamp": {
+            "type": "integer",
+            "title": "Timestamp",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "event",
+          "body"
+        ],
+        "title": "GuestEvent",
+        "description": "Structured lifecycle event emitted by the guest or runtime. Since VMM v0.5.7."
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -25190,43 +22061,6 @@
         ],
         "title": "HourlyBillingResponse",
         "description": "Hourly billing summary with detailed events."
-      },
-      "ImageSpec": {
-        "properties": {
-          "registry": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Registry",
-            "default": "docker.io"
-          },
-          "repository": {
-            "type": "string",
-            "title": "Repository"
-          },
-          "tag": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Tag",
-            "default": "latest"
-          }
-        },
-        "type": "object",
-        "required": [
-          "repository"
-        ],
-        "title": "ImageSpec"
       },
       "ImportItemsRequest": {
         "properties": {
@@ -27202,6 +24036,30 @@
             ],
             "title": "Gateway Slug",
             "description": "Gateway slug identifier"
+          },
+          "kms_guest_agent_endpoint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Kms Guest Agent Endpoint",
+            "description": "KMS guest agent endpoint for attestation"
+          },
+          "gateway_guest_agent_endpoint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gateway Guest Agent Endpoint",
+            "description": "Gateway guest agent endpoint for attestation"
           }
         },
         "type": "object",
@@ -27388,6 +24246,30 @@
             ],
             "title": "Gateway Slug",
             "description": "Update gateway slug identifier"
+          },
+          "kms_guest_agent_endpoint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Kms Guest Agent Endpoint",
+            "description": "Update KMS guest agent endpoint"
+          },
+          "gateway_guest_agent_endpoint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gateway Guest Agent Endpoint",
+            "description": "Update gateway guest agent endpoint"
           }
         },
         "type": "object",
@@ -28172,6 +25054,30 @@
             "title": "Gateway Slug",
             "description": "Gateway slug identifier"
           },
+          "kms_guest_agent_endpoint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Kms Guest Agent Endpoint",
+            "description": "KMS guest agent endpoint for attestation"
+          },
+          "gateway_guest_agent_endpoint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gateway Guest Agent Endpoint",
+            "description": "Gateway guest agent endpoint for attestation"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -28502,6 +25408,7 @@
         "properties": {
           "username": {
             "type": "string",
+            "maxLength": 254,
             "title": "Username"
           },
           "password": {
@@ -28965,42 +25872,6 @@
         "title": "MemberRoleUpdateRequest",
         "description": "Request to change member role."
       },
-      "MemoryQuantity": {
-        "properties": {
-          "value": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "string"
-              }
-            ],
-            "title": "Value"
-          },
-          "suffix": {
-            "type": "string",
-            "enum": [
-              "Ki",
-              "Mi",
-              "Gi",
-              "Ti",
-              "k",
-              "m",
-              "G",
-              "T",
-              ""
-            ],
-            "title": "Suffix",
-            "default": ""
-          }
-        },
-        "type": "object",
-        "required": [
-          "value"
-        ],
-        "title": "MemoryQuantity"
-      },
       "MeteredUsageResponse": {
         "properties": {
           "instance_id": {
@@ -29319,64 +26190,67 @@
         "title": "MonthlyUsageSummaryItem",
         "description": "Monthly usage summary item for reconciliation."
       },
-      "NearAccountInfo": {
+      "NetworkConfigPortMappingEntry": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id",
-            "description": "NEAR account ID (e.g., user.near)"
+          "host_port": {
+            "type": "integer",
+            "maximum": 65535.0,
+            "minimum": 1.0,
+            "title": "Host Port"
           },
-          "name": {
-            "type": "string",
-            "title": "Name",
-            "description": "Display name for the account"
+          "vm_port": {
+            "type": "integer",
+            "maximum": 65535.0,
+            "minimum": 1.0,
+            "title": "Vm Port"
           },
-          "email": {
+          "protocol": {
             "type": "string",
-            "format": "email",
-            "title": "Email",
-            "description": "Email for account recovery"
+            "pattern": "^(tcp|udp)$",
+            "title": "Protocol",
+            "default": "tcp"
           },
-          "password": {
+          "host_address": {
             "type": "string",
-            "maxLength": 128,
-            "minLength": 8,
-            "title": "Password",
-            "description": "Account password"
+            "title": "Host Address",
+            "default": ""
           }
         },
         "type": "object",
         "required": [
-          "id",
-          "name",
-          "email",
-          "password"
+          "host_port",
+          "vm_port"
         ],
-        "title": "NearAccountInfo",
-        "description": "Registration data for a new NEAR user."
+        "title": "NetworkConfigPortMappingEntry",
+        "description": "Single port mapping rule returned from VMM network config."
       },
-      "NearLoginRequest": {
+      "NetworkConfigResponse": {
         "properties": {
-          "email": {
-            "type": "string",
-            "format": "email",
-            "title": "Email",
-            "description": "Registered email address"
+          "kms_urls": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Kms Urls"
           },
-          "password": {
-            "type": "string",
-            "maxLength": 128,
-            "title": "Password",
-            "description": "Account password"
+          "gateway_urls": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Gateway Urls"
+          },
+          "ports": {
+            "items": {
+              "$ref": "#/components/schemas/NetworkConfigPortMappingEntry"
+            },
+            "type": "array",
+            "title": "Ports"
           }
         },
         "type": "object",
-        "required": [
-          "email",
-          "password"
-        ],
-        "title": "NearLoginRequest",
-        "description": "Login credentials for NEAR users."
+        "title": "NetworkConfigResponse",
+        "description": "Real-time network configuration from VMM."
       },
       "NodeCreate": {
         "properties": {
@@ -29524,6 +26398,238 @@
         ],
         "title": "NodeCreate",
         "description": "Input for creating a physical node."
+      },
+      "NodeFirewallRuleOut": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id",
+            "description": "Firewall rule ID"
+          },
+          "protocol": {
+            "type": "string",
+            "title": "Protocol",
+            "description": "Protocol (tcp/udp/tcp+udp)"
+          },
+          "port_from": {
+            "type": "integer",
+            "title": "Port From",
+            "description": "Start port"
+          },
+          "port_to": {
+            "type": "integer",
+            "title": "Port To",
+            "description": "End port"
+          },
+          "comment": {
+            "type": "string",
+            "title": "Comment",
+            "description": "Rule comment"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At",
+            "description": "Rule creation time"
+          },
+          "cvm_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cvm Id",
+            "description": "Parsed CVM ID from comment"
+          },
+          "cvm_host_port": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cvm Host Port",
+            "description": "Parsed host port from comment metadata"
+          },
+          "cvm_vm_port": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cvm Vm Port",
+            "description": "VM-side port from DB mapping"
+          },
+          "cvm_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cvm Name",
+            "description": "CVM display name"
+          },
+          "cvm_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cvm Uuid",
+            "description": "CVM UUID for admin link"
+          },
+          "workspace_slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workspace Slug",
+            "description": "Workspace slug for admin link"
+          },
+          "workspace_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workspace Name",
+            "description": "Workspace display name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "protocol",
+          "port_from",
+          "port_to",
+          "comment"
+        ],
+        "title": "NodeFirewallRuleOut",
+        "description": "Single firewall rule on a node with parsed CVM association."
+      },
+      "NodeFirewallRulesResponse": {
+        "properties": {
+          "node_name": {
+            "type": "string",
+            "title": "Node Name",
+            "description": "Node name"
+          },
+          "rules": {
+            "items": {
+              "$ref": "#/components/schemas/NodeFirewallRuleOut"
+            },
+            "type": "array",
+            "title": "Rules",
+            "description": "Firewall rules"
+          }
+        },
+        "type": "object",
+        "required": [
+          "node_name"
+        ],
+        "title": "NodeFirewallRulesResponse",
+        "description": "Node firewall rules list response."
+      },
+      "NodeNetworkDeviceOut": {
+        "properties": {
+          "device": {
+            "type": "string",
+            "title": "Device",
+            "description": "Network device name"
+          },
+          "monitored_processes": {
+            "type": "integer",
+            "title": "Monitored Processes",
+            "description": "Number of monitored QEMU processes"
+          },
+          "total_sent_bytes": {
+            "type": "integer",
+            "title": "Total Sent Bytes",
+            "description": "Total sent bytes"
+          },
+          "total_recv_bytes": {
+            "type": "integer",
+            "title": "Total Recv Bytes",
+            "description": "Total received bytes"
+          },
+          "sent_kbs_current": {
+            "type": "number",
+            "title": "Sent Kbs Current",
+            "description": "Current send throughput in KB/s"
+          },
+          "recv_kbs_current": {
+            "type": "number",
+            "title": "Recv Kbs Current",
+            "description": "Current receive throughput in KB/s"
+          }
+        },
+        "type": "object",
+        "required": [
+          "device",
+          "monitored_processes",
+          "total_sent_bytes",
+          "total_recv_bytes",
+          "sent_kbs_current",
+          "recv_kbs_current"
+        ],
+        "title": "NodeNetworkDeviceOut",
+        "description": "Single host network device stat."
+      },
+      "NodeNetworkDevicesResponse": {
+        "properties": {
+          "node_name": {
+            "type": "string",
+            "title": "Node Name",
+            "description": "Node name"
+          },
+          "total_monitored_processes": {
+            "type": "integer",
+            "title": "Total Monitored Processes",
+            "description": "Total monitored QEMU processes"
+          },
+          "devices": {
+            "items": {
+              "$ref": "#/components/schemas/NodeNetworkDeviceOut"
+            },
+            "type": "array",
+            "title": "Devices",
+            "description": "Per-device stats"
+          }
+        },
+        "type": "object",
+        "required": [
+          "node_name",
+          "total_monitored_processes"
+        ],
+        "title": "NodeNetworkDevicesResponse",
+        "description": "Host network devices stats for a node."
       },
       "NodeOut": {
         "properties": {
@@ -29723,6 +26829,39 @@
         ],
         "title": "NodeOutagesResponse"
       },
+      "NodeProvider": {
+        "properties": {
+          "proof_of_cloud": {
+            "type": "boolean",
+            "title": "Proof Of Cloud",
+            "description": "Quote from a trusted cloud TEE"
+          },
+          "provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider",
+            "description": "Provider label (e.g. 'phala', 'scrt')"
+          },
+          "ppid": {
+            "type": "string",
+            "title": "Ppid",
+            "description": "Platform Provisioning ID"
+          }
+        },
+        "type": "object",
+        "required": [
+          "proof_of_cloud",
+          "ppid"
+        ],
+        "title": "NodeProvider",
+        "description": "TEE node provider info."
+      },
       "NodeRef": {
         "properties": {
           "object_type": {
@@ -29743,6 +26882,18 @@
             ],
             "title": "Id",
             "description": "Teepod numeric ID"
+          },
+          "node_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Node Id",
+            "description": "Physical node numeric ID"
           },
           "name": {
             "anyOf": [
@@ -29859,6 +27010,442 @@
         ],
         "title": "NodeResourceLimits",
         "description": "Node hardware capacity limits."
+      },
+      "NodeSNITrafficItem": {
+        "properties": {
+          "sni": {
+            "type": "string",
+            "title": "Sni"
+          },
+          "total_bytes": {
+            "type": "integer",
+            "title": "Total Bytes",
+            "default": 0
+          },
+          "connections": {
+            "type": "integer",
+            "title": "Connections",
+            "default": 0
+          },
+          "zero_bytes": {
+            "type": "integer",
+            "title": "Zero Bytes",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "sni"
+        ],
+        "title": "NodeSNITrafficItem",
+        "description": "Traffic stats for a single SNI."
+      },
+      "NodeStorageInfo": {
+        "properties": {
+          "mount_point": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mount Point"
+          },
+          "filesystem": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Filesystem"
+          },
+          "size_kb": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Kb"
+          },
+          "used_kb": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Used Kb"
+          },
+          "avail_kb": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avail Kb"
+          },
+          "use_percentage": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Use Percentage"
+          }
+        },
+        "type": "object",
+        "title": "NodeStorageInfo",
+        "description": "Filesystem storage stats."
+      },
+      "NodeStorageListResponse": {
+        "properties": {
+          "node_name": {
+            "type": "string",
+            "title": "Node Name",
+            "description": "Node name"
+          },
+          "available": {
+            "type": "boolean",
+            "title": "Available",
+            "default": true
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/NodeStorageVMItem"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "node_name"
+        ],
+        "title": "NodeStorageListResponse",
+        "description": "Per-VM storage list for a node, sorted by size desc."
+      },
+      "NodeStorageVMItem": {
+        "properties": {
+          "vm_uuid": {
+            "type": "string",
+            "title": "Vm Uuid"
+          },
+          "size_bytes": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Size Bytes",
+            "default": 0
+          },
+          "exists": {
+            "type": "boolean",
+            "title": "Exists",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "vm_uuid"
+        ],
+        "title": "NodeStorageVMItem",
+        "description": "Storage usage for a single VM from agent."
+      },
+      "NodeSystemInfoResponse": {
+        "properties": {
+          "node_name": {
+            "type": "string",
+            "title": "Node Name",
+            "description": "Node name"
+          },
+          "available": {
+            "type": "boolean",
+            "title": "Available",
+            "description": "Whether agent returned system info"
+          },
+          "unavailable_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unavailable Reason"
+          },
+          "qemu_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Qemu Path"
+          },
+          "qemu_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Qemu Version"
+          },
+          "qemu_package": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Qemu Package"
+          },
+          "cpu_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cpu Model"
+          },
+          "lscpu_model_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lscpu Model Name"
+          },
+          "cpu_microcode_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cpu Microcode Version"
+          },
+          "cpu_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cpu Count"
+          },
+          "memory_gib": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Memory Gib",
+            "description": "Total memory in GiB"
+          },
+          "data_dir_tib": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data Dir Tib",
+            "description": "Data dir size in TiB"
+          },
+          "storage": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/NodeStorageInfo"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Filesystem storage stats"
+          },
+          "mk_tme_max_keys": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mk Tme Max Keys"
+          },
+          "num_tdx_keyids": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Num Tdx Keyids"
+          }
+        },
+        "type": "object",
+        "required": [
+          "node_name",
+          "available"
+        ],
+        "title": "NodeSystemInfoResponse",
+        "description": "System info from node agent including MKTME and storage."
+      },
+      "NodeTeescopeCapabilities": {
+        "properties": {
+          "firewall": {
+            "type": "boolean",
+            "title": "Firewall",
+            "description": "Whether firewall management is supported",
+            "default": false
+          },
+          "netd_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Netd Version",
+            "description": "teescope-netd version"
+          }
+        },
+        "type": "object",
+        "title": "NodeTeescopeCapabilities"
+      },
+      "NodeTeescopeInfoResponse": {
+        "properties": {
+          "node_name": {
+            "type": "string",
+            "title": "Node Name",
+            "description": "Node name"
+          },
+          "api_endpoint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Api Endpoint",
+            "description": "Teescope API endpoint URL"
+          },
+          "version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Version",
+            "description": "Teescope agent version"
+          },
+          "capabilities": {
+            "$ref": "#/components/schemas/NodeTeescopeCapabilities"
+          },
+          "available": {
+            "type": "boolean",
+            "title": "Available",
+            "description": "Whether teescope is reachable"
+          },
+          "unavailable_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unavailable Reason",
+            "description": "Why teescope is unavailable"
+          }
+        },
+        "type": "object",
+        "required": [
+          "node_name",
+          "available"
+        ],
+        "title": "NodeTeescopeInfoResponse",
+        "description": "Teescope agent info for a node."
+      },
+      "NodeTopSNIsResponse": {
+        "properties": {
+          "node_name": {
+            "type": "string",
+            "title": "Node Name",
+            "description": "Node name"
+          },
+          "available": {
+            "type": "boolean",
+            "title": "Available",
+            "default": true
+          },
+          "snis": {
+            "items": {
+              "$ref": "#/components/schemas/NodeSNITrafficItem"
+            },
+            "type": "array",
+            "title": "Snis"
+          },
+          "total_count": {
+            "type": "integer",
+            "title": "Total Count",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "node_name"
+        ],
+        "title": "NodeTopSNIsResponse",
+        "description": "Top SNIs by traffic for a node."
       },
       "NodeUpdate": {
         "properties": {
@@ -30016,6 +27603,453 @@
         "type": "object",
         "title": "NodeUpdate",
         "description": "Input for updating a physical node."
+      },
+      "NodeVMEgressInfo": {
+        "properties": {
+          "total_sent_bytes": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Total Sent Bytes",
+            "default": 0
+          },
+          "total_recv_bytes": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Total Recv Bytes",
+            "default": 0
+          },
+          "peak_sent_kbs": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Peak Sent Kbs",
+            "default": 0.0
+          },
+          "peak_recv_kbs": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Peak Recv Kbs",
+            "default": 0.0
+          },
+          "total_sent_kbs_avg_5m": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Total Sent Kbs Avg 5M",
+            "default": 0.0
+          },
+          "total_recv_kbs_avg_5m": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Total Recv Kbs Avg 5M",
+            "default": 0.0
+          }
+        },
+        "type": "object",
+        "title": "NodeVMEgressInfo",
+        "description": "Egress traffic stats for a VM."
+      },
+      "NodeVMIngressInfo": {
+        "properties": {
+          "app_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "App Id"
+          },
+          "total_bytes": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Total Bytes",
+            "default": 0
+          },
+          "connections": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Connections",
+            "default": 0
+          },
+          "zero_bytes": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Zero Bytes",
+            "default": 0
+          },
+          "snis": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Snis"
+          }
+        },
+        "type": "object",
+        "title": "NodeVMIngressInfo",
+        "description": "Ingress traffic stats for a VM (via HAProxy SNI)."
+      },
+      "NodeVMItem": {
+        "properties": {
+          "vm_uuid": {
+            "type": "string",
+            "title": "Vm Uuid"
+          },
+          "cvm_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cvm Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "description": "CVM display name"
+          },
+          "app_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "App Id",
+            "description": "CVM app ID"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status",
+            "description": "CVM status from DB"
+          },
+          "project_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Project Name"
+          },
+          "workspace_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workspace Name"
+          },
+          "workspace_slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workspace Slug"
+          },
+          "instance_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instance Type"
+          },
+          "disk_size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Disk Size",
+            "description": "Allocated disk in GB from DB"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "qemu": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/NodeVMQemuInfo"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "storage": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/NodeVMStorageInfo"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "egress": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/NodeVMEgressInfo"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "ingress": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/NodeVMIngressInfo"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "vm_uuid"
+        ],
+        "title": "NodeVMItem",
+        "description": "Combined VM info: DB metadata + live agent data."
+      },
+      "NodeVMQemuInfo": {
+        "properties": {
+          "pid": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Pid"
+          },
+          "uptime": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Uptime",
+            "description": "Process uptime in seconds",
+            "default": 0
+          },
+          "cpu_usage_perc": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Cpu Usage Perc",
+            "description": "CPU% relative to allocated cores",
+            "default": 0.0
+          },
+          "cpu_pct_usr": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Cpu Pct Usr",
+            "description": "pidstat %usr, 100 == one core",
+            "default": 0.0
+          },
+          "cpu_pct_system": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Cpu Pct System",
+            "description": "pidstat %system, 100 == one core",
+            "default": 0.0
+          },
+          "cpu_pct_guest": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Cpu Pct Guest",
+            "description": "pidstat %guest, 100 == one core",
+            "default": 0.0
+          },
+          "cpu_pct_wait": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Cpu Pct Wait",
+            "description": "pidstat %wait, 100 == one core",
+            "default": 0.0
+          },
+          "cpu_pct_total": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Cpu Pct Total",
+            "description": "pidstat %CPU = usr+system+guest",
+            "default": 0.0
+          },
+          "cpu_cores": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Cpu Cores",
+            "description": "Allocated CPU cores",
+            "default": 0
+          },
+          "allocated_mb": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Allocated Mb",
+            "description": "Allocated memory in MB",
+            "default": 0
+          },
+          "kvm_guest_mem_mb": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Kvm Guest Mem Mb",
+            "description": "KVM guest memory in MB",
+            "default": 0.0
+          },
+          "kvm_mem_usage_perc": {
+            "type": "number",
+            "minimum": 0.0,
+            "title": "Kvm Mem Usage Perc",
+            "description": "KVM memory usage %",
+            "default": 0.0
+          },
+          "kvm_hugepage_ratio": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Kvm Hugepage Ratio",
+            "description": "Hugepage ratio",
+            "default": 0.0
+          },
+          "oom_score": {
+            "type": "integer",
+            "title": "Oom Score",
+            "description": "OOM score (0-1000)",
+            "default": 0
+          },
+          "io_read_bytes": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Io Read Bytes",
+            "default": 0
+          },
+          "io_write_bytes": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Io Write Bytes",
+            "default": 0
+          },
+          "slots": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Slots",
+            "description": "GPU PCI slots"
+          }
+        },
+        "type": "object",
+        "required": [
+          "pid"
+        ],
+        "title": "NodeVMQemuInfo",
+        "description": "QEMU process resource usage for a VM."
+      },
+      "NodeVMStorageInfo": {
+        "properties": {
+          "size_bytes": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Size Bytes",
+            "default": 0
+          },
+          "exists": {
+            "type": "boolean",
+            "title": "Exists",
+            "default": false
+          }
+        },
+        "type": "object",
+        "title": "NodeVMStorageInfo",
+        "description": "Storage usage for a VM data directory."
+      },
+      "NodeVMsResponse": {
+        "properties": {
+          "node_name": {
+            "type": "string",
+            "title": "Node Name",
+            "description": "Node name"
+          },
+          "available": {
+            "type": "boolean",
+            "title": "Available",
+            "default": true
+          },
+          "vms": {
+            "items": {
+              "$ref": "#/components/schemas/NodeVMItem"
+            },
+            "type": "array",
+            "title": "Vms"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "description": "Total matching VMs",
+            "default": 0
+          },
+          "page": {
+            "type": "integer",
+            "title": "Page",
+            "default": 1
+          },
+          "page_size": {
+            "type": "integer",
+            "title": "Page Size",
+            "default": 50
+          },
+          "pages": {
+            "type": "integer",
+            "title": "Pages",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "node_name"
+        ],
+        "title": "NodeVMsResponse",
+        "description": "Combined VM data for a node."
       },
       "OSImageCreate": {
         "properties": {
@@ -30749,6 +28783,119 @@
         "title": "OperationEventDetail",
         "description": "Single atomic event within an operation."
       },
+      "OrderFinancialSummaryOut": {
+        "properties": {
+          "prepaid_amount": {
+            "type": "string",
+            "title": "Prepaid Amount"
+          },
+          "prepaid_breakdown": {
+            "items": {
+              "$ref": "#/components/schemas/PrepaidBreakdownOut"
+            },
+            "type": "array",
+            "title": "Prepaid Breakdown"
+          },
+          "prepaid_hours": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prepaid Hours"
+          },
+          "hourly_rate": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hourly Rate"
+          },
+          "activated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Activated At"
+          },
+          "used_hours": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Used Hours"
+          }
+        },
+        "type": "object",
+        "required": [
+          "prepaid_amount",
+          "prepaid_breakdown",
+          "prepaid_hours",
+          "hourly_rate",
+          "activated_at",
+          "used_hours"
+        ],
+        "title": "OrderFinancialSummaryOut"
+      },
+      "OrderMinimumPeriodOut": {
+        "properties": {
+          "total_hours": {
+            "type": "integer",
+            "title": "Total Hours"
+          },
+          "ends_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ends At"
+          },
+          "in_minimum_period": {
+            "type": "boolean",
+            "title": "In Minimum Period"
+          },
+          "hours_remaining": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hours Remaining"
+          }
+        },
+        "type": "object",
+        "required": [
+          "total_hours",
+          "ends_at",
+          "in_minimum_period",
+          "hours_remaining"
+        ],
+        "title": "OrderMinimumPeriodOut"
+      },
       "OrderResponse": {
         "properties": {
           "id": {
@@ -30853,6 +29000,54 @@
         ],
         "title": "OrderResponse",
         "description": "Single order in the orders list response."
+      },
+      "OrderRunwayOut": {
+        "properties": {
+          "unmetered": {
+            "type": "boolean",
+            "title": "Unmetered"
+          },
+          "team_credit_balance": {
+            "type": "string",
+            "title": "Team Credit Balance"
+          },
+          "estimated_runway_hours": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Estimated Runway Hours"
+          },
+          "estimated_exhaust_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Estimated Exhaust At"
+          },
+          "assumption_note": {
+            "type": "string",
+            "title": "Assumption Note"
+          }
+        },
+        "type": "object",
+        "required": [
+          "unmetered",
+          "team_credit_balance",
+          "estimated_runway_hours",
+          "estimated_exhaust_at",
+          "assumption_note"
+        ],
+        "title": "OrderRunwayOut"
       },
       "OrderStatus": {
         "type": "string",
@@ -31426,6 +29621,14 @@
             "type": "integer",
             "title": "Total",
             "description": "Total orders matching filters"
+          },
+          "status_counts": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/StatusCount"
+            },
+            "type": "object",
+            "title": "Status Counts",
+            "description": "Order count and total GPU quantity per status"
           }
         },
         "type": "object",
@@ -32196,6 +30399,104 @@
         ],
         "title": "PaymentProvider"
       },
+      "PendingUpdateItem": {
+        "properties": {
+          "vm_uuid": {
+            "type": "string",
+            "title": "Vm Uuid"
+          },
+          "compose_hash": {
+            "type": "string",
+            "title": "Compose Hash"
+          },
+          "on_chain": {
+            "type": "boolean",
+            "title": "On Chain"
+          },
+          "instance_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instance Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "vm_uuid",
+          "compose_hash",
+          "on_chain"
+        ],
+        "title": "PendingUpdateItem"
+      },
+      "PendingUpdatePreview": {
+        "properties": {
+          "current_docker_compose": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Current Docker Compose"
+          },
+          "pending_docker_compose": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pending Docker Compose"
+          },
+          "current_pre_launch_script": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Current Pre Launch Script"
+          },
+          "pending_pre_launch_script": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pending Pre Launch Script"
+          }
+        },
+        "type": "object",
+        "title": "PendingUpdatePreview"
+      },
+      "PendingUpdatesResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/PendingUpdateItem"
+            },
+            "type": "array",
+            "title": "Items",
+            "default": []
+          }
+        },
+        "type": "object",
+        "title": "PendingUpdatesResponse"
+      },
       "PeriodInfo": {
         "properties": {
           "start_date": {
@@ -32365,6 +30666,96 @@
         ],
         "title": "PortMapping"
       },
+      "PortMappingEntry": {
+        "properties": {
+          "vm_port": {
+            "type": "integer",
+            "maximum": 65535.0,
+            "minimum": 1.0,
+            "title": "Vm Port"
+          },
+          "protocol": {
+            "type": "string",
+            "pattern": "^(tcp|udp)$",
+            "title": "Protocol",
+            "default": "tcp"
+          }
+        },
+        "type": "object",
+        "required": [
+          "vm_port"
+        ],
+        "title": "PortMappingEntry",
+        "description": "Single requested port mapping rule."
+      },
+      "PortMappingResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^pm_.+",
+            "format": "hashid",
+            "title": "HashedId[cvm_port_mappings]",
+            "description": "A hashed identifier that maps to an internal database ID",
+            "examples": [
+              "pm_0123abcd"
+            ]
+          },
+          "host_port": {
+            "type": "integer",
+            "title": "Host Port"
+          },
+          "vm_port": {
+            "type": "integer",
+            "title": "Vm Port"
+          },
+          "protocol": {
+            "type": "string",
+            "title": "Protocol"
+          },
+          "host_address": {
+            "type": "string",
+            "title": "Host Address"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "host_port",
+          "vm_port",
+          "protocol",
+          "host_address"
+        ],
+        "title": "PortMappingResponse",
+        "description": "Port mapping with server-assigned ID."
+      },
+      "PrepaidBreakdownOut": {
+        "properties": {
+          "transaction_id": {
+            "type": "string",
+            "title": "Transaction Id"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type"
+          },
+          "amount": {
+            "type": "string",
+            "title": "Amount"
+          },
+          "source": {
+            "type": "string",
+            "title": "Source"
+          }
+        },
+        "type": "object",
+        "required": [
+          "transaction_id",
+          "type",
+          "amount",
+          "source"
+        ],
+        "title": "PrepaidBreakdownOut"
+      },
       "ProfileGetResponse": {
         "properties": {
           "display_name": {
@@ -32446,7 +30837,8 @@
           "custom_domain": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "maxLength": 253
               },
               {
                 "type": "null"
@@ -32874,15 +31266,6 @@
         ],
         "title": "PromotionRedemptionsResponse",
         "description": "Response for promotion redemptions list."
-      },
-      "Protocol": {
-        "type": "string",
-        "enum": [
-          "TCP",
-          "UDP",
-          "SCTP"
-        ],
-        "title": "Protocol"
       },
       "ProvisionComposeFileUpdateRequest": {
         "properties": {
@@ -33357,6 +31740,18 @@
             ],
             "title": "Image",
             "description": "The image to use for the a16z/eliza. If not provided, it will use the latest image."
+          },
+          "kms_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Kms Id",
+            "description": "The KMS ID to use."
           }
         },
         "type": "object",
@@ -34306,6 +32701,184 @@
         ],
         "title": "RedpillConnectionStatus"
       },
+      "RefreshAttestationVerifiedItem": {
+        "properties": {
+          "checksum": {
+            "type": "string",
+            "title": "Checksum"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "would_process",
+              "updated",
+              "unchanged",
+              "failed",
+              "not_found"
+            ],
+            "title": "Status"
+          },
+          "verified": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Verified"
+          },
+          "verified_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Verified At"
+          },
+          "reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reason"
+          }
+        },
+        "type": "object",
+        "required": [
+          "checksum",
+          "status"
+        ],
+        "title": "RefreshAttestationVerifiedItem"
+      },
+      "RefreshAttestationVerifiedRequest": {
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "estimate",
+              "execute"
+            ],
+            "title": "Mode",
+            "description": "Preview affected rows or execute the refresh mutation.",
+            "default": "estimate"
+          },
+          "since": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Since",
+            "description": "Refresh quotes created at or after this timestamp."
+          },
+          "checksums": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Checksums",
+            "description": "Refresh one or more exact quote checksums."
+          },
+          "batch_size": {
+            "type": "integer",
+            "maximum": 500.0,
+            "minimum": 1.0,
+            "title": "Batch Size",
+            "description": "Rows to process per batch.",
+            "default": 100
+          },
+          "limit": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 10000.0,
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Limit",
+            "description": "Optional cap on matched rows after filtering."
+          }
+        },
+        "type": "object",
+        "title": "RefreshAttestationVerifiedRequest"
+      },
+      "RefreshAttestationVerifiedResponse": {
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "estimate",
+              "execute"
+            ],
+            "title": "Mode"
+          },
+          "matched": {
+            "type": "integer",
+            "title": "Matched",
+            "description": "Rows found in ClickHouse for the requested target."
+          },
+          "processed": {
+            "type": "integer",
+            "title": "Processed",
+            "description": "Rows that were inspected in this request."
+          },
+          "updated": {
+            "type": "integer",
+            "title": "Updated",
+            "description": "Rows whose verified boolean changed after refresh."
+          },
+          "unchanged": {
+            "type": "integer",
+            "title": "Unchanged",
+            "description": "Rows refreshed with the same verified boolean."
+          },
+          "failed": {
+            "type": "integer",
+            "title": "Failed",
+            "description": "Rows that failed re-verification."
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/RefreshAttestationVerifiedItem"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "mode",
+          "matched",
+          "processed",
+          "updated",
+          "unchanged",
+          "failed"
+        ],
+        "title": "RefreshAttestationVerifiedResponse"
+      },
       "RegisterPayload": {
         "properties": {
           "username": {
@@ -34319,12 +32892,14 @@
           },
           "password": {
             "type": "string",
+            "maxLength": 128,
             "title": "Password"
           },
           "invite_code": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "maxLength": 100
               },
               {
                 "type": "null"
@@ -34335,7 +32910,8 @@
           "site_key": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "maxLength": 200
               },
               {
                 "type": "null"
@@ -34378,6 +32954,102 @@
         ],
         "title": "RegisterRequest",
         "description": "Shim registration request with DCAP proof."
+      },
+      "RelatedTransactionOut": {
+        "properties": {
+          "transaction_id": {
+            "type": "string",
+            "title": "Transaction Id"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type"
+          },
+          "amount": {
+            "type": "string",
+            "title": "Amount"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          }
+        },
+        "type": "object",
+        "required": [
+          "transaction_id",
+          "type",
+          "amount",
+          "created_at",
+          "description"
+        ],
+        "title": "RelatedTransactionOut"
+      },
+      "ReplicateRequest": {
+        "properties": {
+          "teepod_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Teepod Id",
+            "description": "Target node ID (deprecated, use node_id)"
+          },
+          "node_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Node Id",
+            "description": "Target node ID for the replica"
+          },
+          "encrypted_env": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Encrypted Env",
+            "description": "New encrypted env blob (hex)"
+          },
+          "compose_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Compose Hash",
+            "description": "Explicit compose hash to replicate. Required when the source app has multiple live instances."
+          }
+        },
+        "type": "object",
+        "title": "ReplicateRequest",
+        "description": "Request model for CVM replication."
       },
       "ReservedGpuItem": {
         "properties": {
@@ -34600,70 +33272,6 @@
         ],
         "title": "ResourceMetrics",
         "description": "Resource metrics for CPU, memory, and disk."
-      },
-      "ResourceRequirements": {
-        "properties": {
-          "requests": {
-            "additionalProperties": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "#/components/schemas/CPUQuantity"
-                },
-                {
-                  "$ref": "#/components/schemas/MemoryQuantity"
-                },
-                {
-                  "$ref": "#/components/schemas/DiskQuantity"
-                }
-              ]
-            },
-            "propertyNames": {
-              "enum": [
-                "cpu",
-                "memory",
-                "ephemeral-storage",
-                "storage"
-              ]
-            },
-            "type": "object",
-            "title": "Requests",
-            "default": {}
-          },
-          "limits": {
-            "additionalProperties": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "#/components/schemas/CPUQuantity"
-                },
-                {
-                  "$ref": "#/components/schemas/MemoryQuantity"
-                },
-                {
-                  "$ref": "#/components/schemas/DiskQuantity"
-                }
-              ]
-            },
-            "propertyNames": {
-              "enum": [
-                "cpu",
-                "memory",
-                "ephemeral-storage",
-                "storage"
-              ]
-            },
-            "type": "object",
-            "title": "Limits",
-            "default": {}
-          }
-        },
-        "type": "object",
-        "title": "ResourceRequirements"
       },
       "ResourceSummaryResponse": {
         "properties": {
@@ -35474,49 +34082,6 @@
         "title": "ShutdownDeleteAllCvmsResponse",
         "description": "Summary of shutdown+delete operation."
       },
-      "Spec": {
-        "properties": {
-          "container": {
-            "$ref": "#/components/schemas/Container"
-          },
-          "base_image": {
-            "type": "string",
-            "title": "Base Image",
-            "default": ""
-          },
-          "app_id": {
-            "type": "string",
-            "title": "App Id",
-            "default": ""
-          },
-          "app_env_encrypt_pubkey": {
-            "type": "string",
-            "title": "App Env Encrypt Pubkey",
-            "default": ""
-          },
-          "encrypted_env": {
-            "type": "string",
-            "title": "Encrypted Env",
-            "default": ""
-          },
-          "salt": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Salt"
-          }
-        },
-        "type": "object",
-        "required": [
-          "container"
-        ],
-        "title": "Spec"
-      },
       "SpendingComparisonResponse": {
         "properties": {
           "this_month": {
@@ -35631,6 +34196,58 @@
               "19.99",
               "123.456000"
             ]
+          },
+          "settled_debt_amount": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "decimal",
+                "description": "A monetary value with precise decimal arithmetic",
+                "examples": [
+                  "19.99",
+                  "123.456000"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Settled Debt Amount"
+          },
+          "remaining_debt": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "decimal",
+                "description": "A monetary value with precise decimal arithmetic",
+                "examples": [
+                  "19.99",
+                  "123.456000"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remaining Debt"
+          },
+          "settlement_transaction_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^crt_.+",
+                "format": "hashid",
+                "title": "HashedId[credit_transactions]",
+                "description": "A hashed identifier that maps to an internal database ID",
+                "examples": [
+                  "crt_0123abcd"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Settlement Transaction Id"
           }
         },
         "type": "object",
@@ -35647,6 +34264,8 @@
         "properties": {
           "name": {
             "type": "string",
+            "maxLength": 100,
+            "minLength": 1,
             "title": "Name",
             "description": "Human-readable name for the key"
           },
@@ -35864,6 +34483,23 @@
           "error"
         ],
         "title": "StatusConnectionItem"
+      },
+      "StatusCount": {
+        "properties": {
+          "count": {
+            "type": "integer",
+            "title": "Count",
+            "default": 0
+          },
+          "total_gpus": {
+            "type": "integer",
+            "title": "Total Gpus",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "title": "StatusCount",
+        "description": "Count and GPU total for a given status."
       },
       "StatusResponse": {
         "properties": {
@@ -36154,7 +34790,7 @@
           },
           "gpus": {
             "items": {
-              "$ref": "#/components/schemas/teehouse__api__routes__admin__nodes__GpuModeInfoOut"
+              "$ref": "#/components/schemas/teehouse__api__routes__admin__nodes__schemas__GpuModeInfoOut"
             },
             "type": "array",
             "title": "Gpus",
@@ -36174,7 +34810,7 @@
           },
           "busy_gpus": {
             "items": {
-              "$ref": "#/components/schemas/teehouse__api__routes__admin__nodes__BusyGpuInfoOut"
+              "$ref": "#/components/schemas/teehouse__api__routes__admin__nodes__schemas__BusyGpuInfoOut"
             },
             "type": "array",
             "title": "Busy Gpus",
@@ -36710,6 +35346,156 @@
         "title": "TaskInfo",
         "description": "Celery task details."
       },
+      "TcbEvaluationInstance": {
+        "properties": {
+          "vm_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vm Uuid"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "instance_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instance Id"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          },
+          "image_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Version"
+          },
+          "ppid": {
+            "type": "string",
+            "title": "Ppid",
+            "default": ""
+          },
+          "device_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Device Id"
+          },
+          "evaluation_update": {
+            "type": "string",
+            "const": "early",
+            "title": "Evaluation Update",
+            "default": "early"
+          },
+          "evaluation_ok": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evaluation Ok"
+          },
+          "evaluation_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evaluation Status"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "vm_uuid",
+          "name",
+          "instance_id",
+          "status",
+          "image_version"
+        ],
+        "title": "TcbEvaluationInstance"
+      },
+      "TcbEvaluationResponse": {
+        "properties": {
+          "app_id": {
+            "type": "string",
+            "title": "App Id"
+          },
+          "update": {
+            "type": "string",
+            "const": "early",
+            "title": "Update",
+            "default": "early"
+          },
+          "instances": {
+            "items": {
+              "$ref": "#/components/schemas/TcbEvaluationInstance"
+            },
+            "type": "array",
+            "title": "Instances"
+          }
+        },
+        "type": "object",
+        "required": [
+          "app_id",
+          "instances"
+        ],
+        "title": "TcbEvaluationResponse"
+      },
       "TcbInfo": {
         "properties": {
           "mrtd": {
@@ -37035,6 +35821,106 @@
             ],
             "title": "Redpill Connection Id"
           },
+          "flag_network_config_enabled": {
+            "type": "boolean",
+            "title": "Flag Network Config Enabled",
+            "default": false
+          },
+          "flag_billing_v2_enabled": {
+            "type": "boolean",
+            "title": "Flag Billing V2 Enabled",
+            "default": false
+          },
+          "billing_mode": {
+            "type": "string",
+            "title": "Billing Mode",
+            "default": "prepaid"
+          },
+          "auto_topup_enabled": {
+            "type": "boolean",
+            "title": "Auto Topup Enabled",
+            "default": false
+          },
+          "auto_topup_amount": {
+            "type": "string",
+            "format": "decimal",
+            "title": "Auto Topup Amount",
+            "description": "A monetary value with precise decimal arithmetic",
+            "default": "0.000000",
+            "examples": [
+              "19.99",
+              "123.456000"
+            ]
+          },
+          "auto_topup_threshold": {
+            "type": "string",
+            "format": "decimal",
+            "title": "Auto Topup Threshold",
+            "description": "A monetary value with precise decimal arithmetic",
+            "default": "0.000000",
+            "examples": [
+              "19.99",
+              "123.456000"
+            ]
+          },
+          "auto_topup_daily_spend": {
+            "type": "string",
+            "format": "decimal",
+            "title": "Auto Topup Daily Spend",
+            "description": "A monetary value with precise decimal arithmetic",
+            "default": "0.000000",
+            "examples": [
+              "19.99",
+              "123.456000"
+            ]
+          },
+          "auto_topup_daily_spend_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Auto Topup Daily Spend Date"
+          },
+          "last_auto_topup_failed_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Auto Topup Failed At"
+          },
+          "post_paid_charge_cap": {
+            "type": "string",
+            "format": "decimal",
+            "title": "Post Paid Charge Cap",
+            "description": "A monetary value with precise decimal arithmetic",
+            "default": "0.000000",
+            "examples": [
+              "19.99",
+              "123.456000"
+            ]
+          },
+          "post_paid_grace_deadline": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Post Paid Grace Deadline"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -37281,6 +36167,11 @@
               }
             ],
             "title": "Redpill Connection Id"
+          },
+          "flag_network_config_enabled": {
+            "type": "boolean",
+            "title": "Flag Network Config Enabled",
+            "default": false
           },
           "created_at": {
             "type": "string",
@@ -38989,6 +37880,38 @@
         "title": "TeepodWithStats",
         "description": "Teepod with CVM counts for capacity planning."
       },
+      "TeescopeBatchRequest": {
+        "properties": {
+          "vm_uuids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "maxItems": 200,
+            "title": "Vm Uuids",
+            "description": "VM UUIDs to query (max 200)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "vm_uuids"
+        ],
+        "title": "TeescopeBatchRequest"
+      },
+      "TeescopeBatchResponse": {
+        "properties": {
+          "items": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/CvmTeescopeInfo"
+            },
+            "type": "object",
+            "title": "Items",
+            "description": "Teescope data keyed by vm_uuid"
+          }
+        },
+        "type": "object",
+        "title": "TeescopeBatchResponse"
+      },
       "TelegramConfigResponse": {
         "properties": {
           "chat_id": {
@@ -39119,33 +38042,6 @@
         ],
         "title": "ToggleMaintenanceResponse",
         "description": "Response after toggling maintenance mode."
-      },
-      "TokenResponse": {
-        "properties": {
-          "access_token": {
-            "type": "string",
-            "title": "Access Token",
-            "description": "JWT access token"
-          },
-          "token_type": {
-            "type": "string",
-            "title": "Token Type",
-            "description": "Token type, always 'bearer'"
-          },
-          "expires_in": {
-            "type": "integer",
-            "title": "Expires In",
-            "description": "Token lifetime in seconds"
-          }
-        },
-        "type": "object",
-        "required": [
-          "access_token",
-          "token_type",
-          "expires_in"
-        ],
-        "title": "TokenResponse",
-        "description": "JWT token response."
       },
       "TopupRequest": {
         "properties": {
@@ -39457,6 +38353,53 @@
         "title": "UpdateAttestationDataRequest",
         "description": "Request to update node attestation data."
       },
+      "UpdateAutoTopupRequest": {
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "title": "Enabled"
+          },
+          "amount": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "decimal",
+                "description": "A monetary value with precise decimal arithmetic",
+                "examples": [
+                  "19.99",
+                  "123.456000"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Amount"
+          },
+          "threshold": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "decimal",
+                "description": "A monetary value with precise decimal arithmetic",
+                "examples": [
+                  "19.99",
+                  "123.456000"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Threshold"
+          }
+        },
+        "type": "object",
+        "required": [
+          "enabled"
+        ],
+        "title": "UpdateAutoTopupRequest"
+      },
       "UpdateBillingSettingsRequest": {
         "properties": {
           "billing_email": {
@@ -39516,6 +38459,19 @@
           "billing_status"
         ],
         "title": "UpdateBillingStatusResponse"
+      },
+      "UpdateBillingV2Request": {
+        "properties": {
+          "flag_billing_v2_enabled": {
+            "type": "boolean",
+            "title": "Flag Billing V2 Enabled"
+          }
+        },
+        "type": "object",
+        "required": [
+          "flag_billing_v2_enabled"
+        ],
+        "title": "UpdateBillingV2Request"
       },
       "UpdateConnectionRequest": {
         "properties": {
@@ -40237,6 +39193,47 @@
         "title": "UpdateMemberRoleRequest",
         "description": "Request to update a member's role."
       },
+      "UpdateNetworkConfigRequest": {
+        "properties": {
+          "kms_urls": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Kms Urls"
+          },
+          "gateway_urls": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gateway Urls"
+          },
+          "restart": {
+            "type": "boolean",
+            "title": "Restart",
+            "description": "Restart the CVM after applying changes to reload configuration.",
+            "default": false
+          }
+        },
+        "type": "object",
+        "title": "UpdateNetworkConfigRequest",
+        "description": "Partial update for KMS/Gateway URLs. Only set fields are applied."
+      },
       "UpdatePasswordRequest": {
         "properties": {
           "password": {
@@ -40296,6 +39293,55 @@
         ],
         "title": "UpdatePaymentModeRequest",
         "description": "Request model for updating payment mode."
+      },
+      "UpdatePortMappingsRequest": {
+        "properties": {
+          "ports": {
+            "items": {
+              "$ref": "#/components/schemas/PortMappingEntry"
+            },
+            "type": "array",
+            "title": "Ports"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ports"
+        ],
+        "title": "UpdatePortMappingsRequest",
+        "description": "Bulk-replace all port mappings for a CVM."
+      },
+      "UpdatePostPaidCapRequest": {
+        "properties": {
+          "charge_cap": {
+            "type": "string",
+            "format": "decimal",
+            "title": "Charge Cap",
+            "description": "A monetary value with precise decimal arithmetic",
+            "examples": [
+              "19.99",
+              "123.456000"
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "charge_cap"
+        ],
+        "title": "UpdatePostPaidCapRequest"
+      },
+      "UpdatePostPaidRequest": {
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "title": "Enabled"
+          }
+        },
+        "type": "object",
+        "required": [
+          "enabled"
+        ],
+        "title": "UpdatePostPaidRequest"
       },
       "UpdateRegionRequest": {
         "properties": {
@@ -41371,6 +40417,18 @@
             "title": "Uploaded At",
             "description": "ISO8601 upload timestamp"
           },
+          "verified_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Verified At",
+            "description": "ISO8601 timestamp when verified was computed"
+          },
           "quote_collateral": {
             "anyOf": [
               {
@@ -41381,6 +40439,17 @@
               }
             ],
             "description": "TCB collateral data"
+          },
+          "node_provider": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/NodeProvider"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Node provider info"
           }
         },
         "type": "object",
@@ -41678,6 +40747,13 @@
               }
             ],
             "title": "Image Version"
+          },
+          "events": {
+            "items": {
+              "$ref": "#/components/schemas/GuestEvent"
+            },
+            "type": "array",
+            "title": "Events"
           }
         },
         "type": "object",
@@ -41819,7 +40895,8 @@
           "name": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "maxLength": 100
               },
               {
                 "type": "null"
@@ -42067,7 +41144,8 @@
           "name": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "maxLength": 100
               },
               {
                 "type": "null"
@@ -42302,6 +41380,20 @@
           "gpus"
         ],
         "title": "WorkspaceReservedGpuQuota"
+      },
+      "WorkspaceResolveResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id",
+            "description": "Canonical workspace hash ID (wks_xxx)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "title": "WorkspaceResolveResponse"
       },
       "WorkspaceResponse": {
         "properties": {
@@ -42864,7 +41956,7 @@
         ],
         "title": "PaginatedInvoices"
       },
-      "teehouse__api__routes__admin__nodes__BusyGpuInfoOut": {
+      "teehouse__api__routes__admin__nodes__schemas__BusyGpuInfoOut": {
         "properties": {
           "slot": {
             "type": "string",
@@ -42899,7 +41991,7 @@
         "title": "BusyGpuInfoOut",
         "description": "GPU that blocked mode switch due to active usage."
       },
-      "teehouse__api__routes__admin__nodes__GpuModeInfoOut": {
+      "teehouse__api__routes__admin__nodes__schemas__GpuModeInfoOut": {
         "properties": {
           "slot": {
             "type": "string",
@@ -42926,7 +42018,7 @@
         "title": "GpuModeInfoOut",
         "description": "GPU mode state after switch."
       },
-      "teehouse__api__routes__admin__nodes__NodeResourceUsage": {
+      "teehouse__api__routes__admin__nodes__schemas__NodeResourceUsage": {
         "properties": {
           "used_vcpu": {
             "type": "number",
@@ -43021,7 +42113,7 @@
         "title": "NodeResourceUsage",
         "description": "Node resource utilization statistics."
       },
-      "teehouse__api__routes__admin__nodes__TeepodCapacity": {
+      "teehouse__api__routes__admin__nodes__schemas__TeepodCapacity": {
         "properties": {
           "max_cvm_number": {
             "anyOf": [
@@ -43594,49 +42686,6 @@
         ],
         "title": "InstanceEventResponse",
         "description": "CVM instance lifecycle event."
-      },
-      "teehouse__api__routes__apps__schemas__ReplicateRequest": {
-        "properties": {
-          "teepod_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Teepod Id",
-            "description": "Target node ID (deprecated, use node_id)"
-          },
-          "node_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Node Id",
-            "description": "Target node ID for replica"
-          },
-          "encrypted_env": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Encrypted Env",
-            "description": "Hex-encoded encrypted environment"
-          }
-        },
-        "type": "object",
-        "title": "ReplicateRequest",
-        "description": "CVM replication request parameters."
       },
       "teehouse__api__routes__apps__v20251028__schemas__CvmBasicInfo": {
         "properties": {
@@ -44296,49 +43345,6 @@
         ],
         "title": "DailyUsageResponse",
         "description": "Daily usage summary with per-instance breakdown."
-      },
-      "teehouse__api__routes__cvms__deployment__ReplicateRequest": {
-        "properties": {
-          "teepod_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Teepod Id",
-            "description": "Target node ID (deprecated, use node_id)"
-          },
-          "node_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Node Id",
-            "description": "Target node ID for the replica"
-          },
-          "encrypted_env": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Encrypted Env",
-            "description": "New encrypted env blob (hex)"
-          }
-        },
-        "type": "object",
-        "title": "ReplicateRequest",
-        "description": "Request model for CVM replication (currently disabled)."
       },
       "teehouse__api__routes__cvms__management__CvmBasicInfo": {
         "properties": {
@@ -45018,6 +44024,11 @@
             "type": "string",
             "title": "Status"
           },
+          "in_progress": {
+            "type": "boolean",
+            "title": "In Progress",
+            "default": false
+          },
           "progress": {
             "anyOf": [
               {
@@ -45063,6 +44074,9 @@
           },
           "gateway": {
             "$ref": "#/components/schemas/CVMGatewayInfo"
+          },
+          "logs": {
+            "$ref": "#/components/schemas/CVMLogUrls"
           },
           "services": {
             "items": {
@@ -45648,95 +44662,32 @@
   },
   "tags": [
     {
-      "name": "Authentication",
-      "description": "User authentication, session management, and authorization for Phala Cloud",
-      "x-mint": {
-        "href": "https://cloud.phala.network/api-reference/authentication"
-      }
-    },
-    {
       "name": "CVMs",
-      "description": "Confidential Virtual Machine (CVM) lifecycle management on Phala Network",
-      "x-mint": {
-        "href": "https://cloud.phala.network/api-reference/cvms"
-      }
+      "description": "Confidential Virtual Machine (CVM) lifecycle management on Phala Network"
     },
     {
       "name": "Apps",
-      "description": "App template management and CVM deployment from app blueprints",
-      "x-mint": {
-        "href": "https://cloud.phala.network/api-reference/apps"
-      }
+      "description": "App template management and CVM deployment from app blueprints"
     },
     {
-      "name": "Workspace",
-      "description": "Workspace settings, members, and configuration",
-      "x-mint": {
-        "href": "https://cloud.phala.network/api-reference/workspace"
-      }
-    },
-    {
-      "name": "Billing",
-      "description": "Subscription plans, payment methods, invoices, and credits",
-      "x-mint": {
-        "href": "https://cloud.phala.network/api-reference/billing"
-      }
+      "name": "Webhooks",
+      "description": "Manage webhook endpoints and monitor delivery history"
     },
     {
       "name": "SSH Keys",
-      "description": "SSH public key management for CVM access",
-      "x-mint": {
-        "href": "https://cloud.phala.network/api-reference/ssh-keys"
-      }
+      "description": "SSH public key management for CVM access"
     },
     {
       "name": "KMS",
-      "description": "Key Management Service — key derivation, on-chain anchoring, and inspection",
-      "x-mint": {
-        "href": "https://cloud.phala.network/api-reference/kms"
-      }
+      "description": "Key Management Service — key derivation, on-chain anchoring, and inspection"
     },
     {
       "name": "Instance Types",
-      "description": "Available hardware configurations for CVM deployment",
-      "x-mint": {
-        "href": "https://cloud.phala.network/api-reference/instance-types"
-      }
+      "description": "Available hardware configurations for CVM deployment"
     },
     {
       "name": "Attestations",
-      "description": "Remote attestation and TEE verification endpoints",
-      "x-mint": {
-        "href": "https://cloud.phala.network/api-reference/attestations"
-      }
-    },
-    {
-      "name": "Usage",
-      "description": "Resource usage analytics and consumption metrics",
-      "x-mint": {
-        "href": "https://cloud.phala.network/api-reference/usage"
-      }
-    },
-    {
-      "name": "Profiles",
-      "description": "User profile management",
-      "x-mint": {
-        "href": "https://cloud.phala.network/api-reference/profiles"
-      }
-    },
-    {
-      "name": "Tokens",
-      "description": "API token lifecycle management",
-      "x-mint": {
-        "href": "https://cloud.phala.network/api-reference/tokens"
-      }
-    },
-    {
-      "name": "GPUs",
-      "description": "GPU availability and specifications",
-      "x-mint": {
-        "href": "https://cloud.phala.network/api-reference/gpus"
-      }
+      "description": "Remote attestation and TEE verification endpoints"
     }
   ]
 }

--- a/phala-cloud/phala-cloud-cli/allow-devices.mdx
+++ b/phala-cloud/phala-cloud-cli/allow-devices.mdx
@@ -1,25 +1,26 @@
 ---
 title: "allow-devices"
 description: "Manage on-chain device allowlist for an app contract"
+hidden: true
 ---
 
 <Note>
 This command is marked as unstable and may change in future releases.
 </Note>
 
-## Command: `phala allow-devices`
+### Command: `phala allow-devices`
 
-### Syntax
+#### Syntax
 
 ```
 phala allow-devices <command> [options]
 ```
 
-### Description
+#### Description
 
 Manage on-chain device allowlist for an app contract
 
-### Global Options
+#### Global Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -32,6 +33,13 @@ Manage on-chain device allowlist for an app contract
 | `--profile PROFILE` | Temporarily use a different auth profile for this command |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
+#### Examples
+
+* Display help:
+
+```bash
+phala allow-devices --help
+```
 ### Subcommands
 
 | Command | Description |
@@ -43,10 +51,3 @@ Manage on-chain device allowlist for an app contract
 | `disallow-any` | Disable allow-any-device on the contract. Equivalent to `allow-any --disable`. |
 | `toggle-allow-any` | Toggle allow-any-device on the contract (or force via --enable/--disable) |
 
-### Examples
-
-* Display help:
-
-```bash
-phala allow-devices --help
-```

--- a/phala-cloud/phala-cloud-cli/allow-devices/add.mdx
+++ b/phala-cloud/phala-cloud-cli/allow-devices/add.mdx
@@ -1,0 +1,68 @@
+---
+title: "allow-devices add"
+description: "Add devices to the on-chain allowlist"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala allow-devices add`
+
+### Syntax
+
+```
+phala allow-devices add [options] <cvm> [<device_id>]
+```
+
+### Description
+
+Add devices to the on-chain allowlist
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<cvm>` | CVM or app identifier (UUID, app_id, instance_id, or name) |
+| `<device_id>?` | Device ID (bytes32 hex) or node name. Node names are resolved to device IDs from available nodes. |
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `--wait` | Wait for on-chain state to reflect the change via RPC polling |
+
+### Advanced Options
+
+| Option | Description |
+| ------ | ----------- |
+| `--private-key <value>` | Private key for signing on-chain transactions (or set PRIVATE_KEY env var) |
+| `--rpc-url <value>` | RPC URL for on-chain KMS transactions (or set ETH_RPC_URL env var) |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `-i, --interactive` | Enable interactive mode |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Add device to allowlist
+
+```bash
+phala allow-devices add app_abc123 0xaabb... --private-key 0x...
+```
+
+* Interactive multi-select from available nodes
+
+```bash
+phala allow-devices add app_abc123 -i --private-key 0x...
+```
+

--- a/phala-cloud/phala-cloud-cli/allow-devices/allow-any.mdx
+++ b/phala-cloud/phala-cloud-cli/allow-devices/allow-any.mdx
@@ -1,0 +1,69 @@
+---
+title: "allow-devices allow-any"
+description: "Set the allow-any-device flag on the contract. Requires --enable or --disable."
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala allow-devices allow-any`
+
+### Syntax
+
+```
+phala allow-devices allow-any [options] <cvm>
+```
+
+### Description
+
+Set the allow-any-device flag on the contract. Requires --enable or --disable.
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<cvm>` | CVM or app identifier (UUID, app_id, instance_id, or name) |
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `--enable` | Enable allow-any-device |
+| `--disable` | Disable allow-any-device |
+| `--wait` | Wait for on-chain state to reflect the change via RPC polling |
+
+### Advanced Options
+
+| Option | Description |
+| ------ | ----------- |
+| `--private-key <value>` | Private key for signing on-chain transactions (or set PRIVATE_KEY env var) |
+| `--rpc-url <value>` | RPC URL for on-chain KMS transactions (or set ETH_RPC_URL env var) |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Enable allow-any-device
+
+```bash
+phala allow-devices allow-any app_abc123 --enable --private-key 0x...
+```
+
+* Disable allow-any-device
+
+```bash
+phala allow-devices allow-any app_abc123 --disable --private-key 0x...
+```
+

--- a/phala-cloud/phala-cloud-cli/allow-devices/disallow-any.mdx
+++ b/phala-cloud/phala-cloud-cli/allow-devices/disallow-any.mdx
@@ -1,0 +1,61 @@
+---
+title: "allow-devices disallow-any"
+description: "Disable allow-any-device on the contract. Equivalent to `allow-any --disable`."
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala allow-devices disallow-any`
+
+### Syntax
+
+```
+phala allow-devices disallow-any [options] <cvm>
+```
+
+### Description
+
+Disable allow-any-device on the contract. Equivalent to `allow-any --disable`.
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<cvm>` | CVM or app identifier (UUID, app_id, instance_id, or name) |
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `--wait` | Wait for on-chain state to reflect the change via RPC polling |
+
+### Advanced Options
+
+| Option | Description |
+| ------ | ----------- |
+| `--private-key <value>` | Private key for signing on-chain transactions (or set PRIVATE_KEY env var) |
+| `--rpc-url <value>` | RPC URL for on-chain KMS transactions (or set ETH_RPC_URL env var) |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Disable allow-any-device
+
+```bash
+phala allow-devices disallow-any app_abc123 --private-key 0x...
+```
+

--- a/phala-cloud/phala-cloud-cli/allow-devices/list.mdx
+++ b/phala-cloud/phala-cloud-cli/allow-devices/list.mdx
@@ -1,0 +1,54 @@
+---
+title: "allow-devices list"
+description: "List allowed devices from the on-chain contract"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala allow-devices list`
+
+### Syntax
+
+```
+phala allow-devices list [options] <cvm>
+```
+
+### Description
+
+List allowed devices from the on-chain contract
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<cvm>` | CVM or app identifier (UUID, app_id, instance_id, or name) |
+
+### Advanced Options
+
+| Option | Description |
+| ------ | ----------- |
+| `--rpc-url <value>` | RPC URL for on-chain KMS transactions (or set ETH_RPC_URL env var) |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* List devices on-chain
+
+```bash
+phala allow-devices list app_abc123
+```
+

--- a/phala-cloud/phala-cloud-cli/allow-devices/remove.mdx
+++ b/phala-cloud/phala-cloud-cli/allow-devices/remove.mdx
@@ -1,0 +1,68 @@
+---
+title: "allow-devices remove"
+description: "Remove devices from the on-chain allowlist"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala allow-devices remove`
+
+### Syntax
+
+```
+phala allow-devices remove [options] <cvm> [<device_id>]
+```
+
+### Description
+
+Remove devices from the on-chain allowlist
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<cvm>` | CVM or app identifier (UUID, app_id, instance_id, or name) |
+| `<device_id>?` | Device ID (bytes32 hex) or node name. Node names are resolved to device IDs from available nodes. |
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `--wait` | Wait for on-chain state to reflect the change via RPC polling |
+
+### Advanced Options
+
+| Option | Description |
+| ------ | ----------- |
+| `--private-key <value>` | Private key for signing on-chain transactions (or set PRIVATE_KEY env var) |
+| `--rpc-url <value>` | RPC URL for on-chain KMS transactions (or set ETH_RPC_URL env var) |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `-i, --interactive` | Enable interactive mode |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Remove device from allowlist
+
+```bash
+phala allow-devices remove app_abc123 0xaabb... --private-key 0x...
+```
+
+* Interactive multi-select from allowed devices
+
+```bash
+phala allow-devices remove app_abc123 -i --private-key 0x...
+```
+

--- a/phala-cloud/phala-cloud-cli/allow-devices/toggle-allow-any.mdx
+++ b/phala-cloud/phala-cloud-cli/allow-devices/toggle-allow-any.mdx
@@ -1,0 +1,69 @@
+---
+title: "allow-devices toggle-allow-any"
+description: "Toggle allow-any-device on the contract (or force via --enable/--disable)"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala allow-devices toggle-allow-any`
+
+### Syntax
+
+```
+phala allow-devices toggle-allow-any [options] <cvm>
+```
+
+### Description
+
+Toggle allow-any-device on the contract (or force via --enable/--disable)
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<cvm>` | CVM or app identifier (UUID, app_id, instance_id, or name) |
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `--enable` | Force enable allow-any-device |
+| `--disable` | Force disable allow-any-device |
+| `--wait` | Wait for on-chain state to reflect the change via RPC polling |
+
+### Advanced Options
+
+| Option | Description |
+| ------ | ----------- |
+| `--private-key <value>` | Private key for signing on-chain transactions (or set PRIVATE_KEY env var) |
+| `--rpc-url <value>` | RPC URL for on-chain KMS transactions (or set ETH_RPC_URL env var) |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Toggle based on current state
+
+```bash
+phala allow-devices toggle-allow-any app_abc123 --private-key 0x...
+```
+
+* Force enable
+
+```bash
+phala allow-devices toggle-allow-any app_abc123 --enable --private-key 0x...
+```
+

--- a/phala-cloud/phala-cloud-cli/api.mdx
+++ b/phala-cloud/phala-cloud-cli/api.mdx
@@ -7,25 +7,25 @@ description: "Make an authenticated HTTP request to Phala Cloud API."
 This command is marked as unstable and may change in future releases.
 </Note>
 
-## Command: `phala api`
+### Command: `phala api`
 
-### Syntax
+#### Syntax
 
 ```
 phala api [options] <endpoint>
 ```
 
-### Description
+#### Description
 
 Make an authenticated HTTP request to Phala Cloud API.
 
-### Arguments
+#### Arguments
 
 | Argument | Description |
 | -------- | ----------- |
 | `<endpoint>` | API endpoint path |
 
-### Options
+#### Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -39,7 +39,7 @@ Make an authenticated HTTP request to Phala Cloud API.
 | `-q, --jq <value>` | Filter output with jq expression |
 | `--silent` | Don't print response body |
 
-### Global Options
+#### Global Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -51,7 +51,7 @@ Make an authenticated HTTP request to Phala Cloud API.
 | `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
-### Examples
+#### Examples
 
 * List CVMs
 

--- a/phala-cloud/phala-cloud-cli/apps.mdx
+++ b/phala-cloud/phala-cloud-cli/apps.mdx
@@ -7,19 +7,19 @@ description: "List dstack apps"
 This command is marked as unstable and may change in future releases.
 </Note>
 
-## Command: `phala apps`
+### Command: `phala apps`
 
-### Syntax
+#### Syntax
 
 ```
 phala apps [options]
 ```
 
-### Description
+#### Description
 
 List dstack apps
 
-### Options
+#### Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -34,7 +34,7 @@ List dstack apps
 | `--node <value>` | Filter by node name |
 | `--region <value>` | Filter by region identifier |
 
-### Global Options
+#### Global Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -47,7 +47,7 @@ List dstack apps
 | `--profile PROFILE` | Temporarily use a different auth profile for this command |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
-### Examples
+#### Examples
 
 * List apps
 

--- a/phala-cloud/phala-cloud-cli/auth.mdx
+++ b/phala-cloud/phala-cloud-cli/auth.mdx
@@ -1,25 +1,26 @@
 ---
 title: "auth (Deprecated)"
 description: "Authenticate with Phala Cloud"
+hidden: true
 ---
 
 <Warning>
 This command is deprecated. Use `phala login`, `phala logout`, and `phala status` instead.
 </Warning>
 
-## Command: `phala auth`
+### Command: `phala auth`
 
-### Syntax
+#### Syntax
 
 ```
 phala auth <command> [options]
 ```
 
-### Description
+#### Description
 
 Authenticate with Phala Cloud
 
-### Global Options
+#### Global Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -32,6 +33,13 @@ Authenticate with Phala Cloud
 | `--profile PROFILE` | Temporarily use a different auth profile for this command |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
+#### Examples
+
+* Display help:
+
+```bash
+phala auth --help
+```
 ### Deprecated Subcommands
 
 | Command | Description |
@@ -40,10 +48,3 @@ Authenticate with Phala Cloud
 | `logout` | Remove stored API key (use 'phala logout' instead) |
 | `status` | Check auth status (use 'phala status' instead) |
 
-### Examples
-
-* Display help:
-
-```bash
-phala auth --help
-```

--- a/phala-cloud/phala-cloud-cli/auth/login.mdx
+++ b/phala-cloud/phala-cloud-cli/auth/login.mdx
@@ -1,0 +1,53 @@
+---
+title: "auth login (Deprecated)"
+description: "Authenticate with Phala Cloud (use 'phala login' instead)"
+---
+
+<Warning>
+This command is deprecated. See the newer alternatives.
+</Warning>
+
+## Command: `phala auth login`
+
+### Syntax
+
+```
+phala auth login [options] [<api-key>]
+```
+
+### Description
+
+Authenticate with Phala Cloud (use 'phala login' instead)
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<api-key>?` | API key (triggers device flow if omitted) |
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `--manual` | Enter API key manually |
+| `--no-open` | Skip browser launch |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Display help:
+
+```bash
+phala auth login --help
+```

--- a/phala-cloud/phala-cloud-cli/auth/logout.mdx
+++ b/phala-cloud/phala-cloud-cli/auth/logout.mdx
@@ -1,0 +1,41 @@
+---
+title: "auth logout (Deprecated)"
+description: "Remove stored API key (use 'phala logout' instead)"
+---
+
+<Warning>
+This command is deprecated. See the newer alternatives.
+</Warning>
+
+## Command: `phala auth logout`
+
+### Syntax
+
+```
+phala auth logout
+```
+
+### Description
+
+Remove stored API key (use 'phala logout' instead)
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Display help:
+
+```bash
+phala auth logout --help
+```

--- a/phala-cloud/phala-cloud-cli/auth/status.mdx
+++ b/phala-cloud/phala-cloud-cli/auth/status.mdx
@@ -1,0 +1,47 @@
+---
+title: "auth status (Deprecated)"
+description: "Check auth status (use 'phala status' instead)"
+---
+
+<Warning>
+This command is deprecated. See the newer alternatives.
+</Warning>
+
+## Command: `phala auth status`
+
+### Syntax
+
+```
+phala auth status [options]
+```
+
+### Description
+
+Check auth status (use 'phala status' instead)
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-d, --debug` | Enable debug output |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Display help:
+
+```bash
+phala auth status --help
+```

--- a/phala-cloud/phala-cloud-cli/changelog.mdx
+++ b/phala-cloud/phala-cloud-cli/changelog.mdx
@@ -3,6 +3,26 @@ title: Changelog
 description: Release history for the Phala Cloud CLI
 ---
 
+## [1.1.18](https://github.com/Phala-Network/phala-cloud/compare/cli-v1.1.17...cli-v1.1.18) (2026-04-17)
+
+### feat
+
+* **cli:** add instances rm command with multi-UUID support ([0f78fc6](https://github.com/Phala-Network/phala-cloud/commit/0f78fc63116b65368830a13df387df50d819b87d))
+* **cli:** move apps instances to top-level instances command, add instances ls ([67046a1](https://github.com/Phala-Network/phala-cloud/commit/67046a18644c3e84a022c0bf66d67fbb5964081a))
+* **sdk,cli:** add POST /apps/{app_id}/instances support ([80498ab](https://github.com/Phala-Network/phala-cloud/commit/80498ab02f56610a21cbbc807b92d878304a1eb2))
+
+### fix
+
+* **cli:** include live status in instances ls --json output ([06b0360](https://github.com/Phala-Network/phala-cloud/commit/06b0360ed7d28779d61335facf51666f27fc2892))
+* **cli:** polish instances/link UX and add commit-token routing ([4ab23c5](https://github.com/Phala-Network/phala-cloud/commit/4ab23c52f51abd73f13de2a28213f8f1ba36b20c))
+* **cli:** poll both deviceAllowed and composeHashAllowed before commit ([755a256](https://github.com/Phala-Network/phala-cloud/commit/755a256e47e38c82d3566fedf30b53d7a278500f))
+* **cli:** poll on-chain state before commit after registering compose hash ([2fb4094](https://github.com/Phala-Network/phala-cloud/commit/2fb409430f06a3bc530d0e5841fb4be567f0a936))
+* **cli:** preserve all existing fields when backfilling app_id in link ([1108cc7](https://github.com/Phala-Network/phala-cloud/commit/1108cc7415fb300595381d516c4535b4900ae21b))
+* **cli:** reject unknown subcommand paths for leaf commands ([397b92b](https://github.com/Phala-Network/phala-cloud/commit/397b92b9e0ccf3c2073a13f9a753901fe8bb4ec6))
+* **cli:** resolve profile by workspace slug fallback and use actual profile key in link ([a06748b](https://github.com/Phala-Network/phala-cloud/commit/a06748ba58f2874b90dcb3bdd363b1b6e8408028))
+* **cli:** skip CVM fetch in instances add when no env-file provided ([98bb666](https://github.com/Phala-Network/phala-cloud/commit/98bb6668700b4ca9f4b6e812a85424a36eadd719))
+* **cli:** write workspace slug as profile key, not workspace name ([e707e84](https://github.com/Phala-Network/phala-cloud/commit/e707e846b62023f3b5436785f346748d6c56dddd))
+
 ## [1.1.16](https://github.com/Phala-Network/phala-cloud/compare/cli-v1.1.15...cli-v1.1.16) (2026-04-10)
 
 ### fix

--- a/phala-cloud/phala-cloud-cli/config.mdx
+++ b/phala-cloud/phala-cloud-cli/config.mdx
@@ -1,25 +1,26 @@
 ---
 title: "config (Deprecated)"
 description: "Manage local CLI state"
+hidden: true
 ---
 
 <Warning>
 This command is deprecated. See the newer alternatives.
 </Warning>
 
-## Command: `phala config`
+### Command: `phala config`
 
-### Syntax
+#### Syntax
 
 ```
 phala config <command> [options]
 ```
 
-### Description
+#### Description
 
 Manage local CLI state
 
-### Global Options
+#### Global Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -32,6 +33,13 @@ Manage local CLI state
 | `--profile PROFILE` | Temporarily use a different auth profile for this command |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
+#### Examples
+
+* Display help:
+
+```bash
+phala config --help
+```
 ### Subcommands
 
 | Command | Description |
@@ -40,10 +48,3 @@ Manage local CLI state
 | `list` | List config values |
 | `set` | Set a configuration value |
 
-### Examples
-
-* Display help:
-
-```bash
-phala config --help
-```

--- a/phala-cloud/phala-cloud-cli/config/get.mdx
+++ b/phala-cloud/phala-cloud-cli/config/get.mdx
@@ -1,0 +1,43 @@
+---
+title: "config get"
+description: "Get a configuration value"
+---
+
+## Command: `phala config get`
+
+### Syntax
+
+```
+phala config get <key>
+```
+
+### Description
+
+Get a configuration value
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<key>` | Configuration key |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Display help:
+
+```bash
+phala config get --help
+```

--- a/phala-cloud/phala-cloud-cli/config/list.mdx
+++ b/phala-cloud/phala-cloud-cli/config/list.mdx
@@ -1,0 +1,37 @@
+---
+title: "config list"
+description: "List config values"
+---
+
+## Command: `phala config list`
+
+### Syntax
+
+```
+phala config list [options]
+```
+
+### Description
+
+List config values
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Display help:
+
+```bash
+phala config list --help
+```

--- a/phala-cloud/phala-cloud-cli/config/set.mdx
+++ b/phala-cloud/phala-cloud-cli/config/set.mdx
@@ -1,0 +1,44 @@
+---
+title: "config set"
+description: "Set a configuration value"
+---
+
+## Command: `phala config set`
+
+### Syntax
+
+```
+phala config set <key> <value>
+```
+
+### Description
+
+Set a configuration value
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<key>` | Configuration key |
+| `<value>` | Configuration value |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Display help:
+
+```bash
+phala config set --help
+```

--- a/phala-cloud/phala-cloud-cli/cp.mdx
+++ b/phala-cloud/phala-cloud-cli/cp.mdx
@@ -7,26 +7,26 @@ description: "Copy files to/from a CVM via SCP"
 This command is marked as unstable and may change in future releases.
 </Note>
 
-## Command: `phala cp`
+### Command: `phala cp`
 
-### Syntax
+#### Syntax
 
 ```
 phala cp [options] <source> <destination>
 ```
 
-### Description
+#### Description
 
 Copy files to/from a CVM via SCP
 
-### Arguments
+#### Arguments
 
 | Argument | Description |
 | -------- | ----------- |
 | `<source>` | Source path (local or cvm-name:path, use :path for phala.toml cvm_id) |
 | `<destination>` | Destination path (local or cvm-name:path, use :path for phala.toml cvm_id) |
 
-### Options
+#### Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -37,7 +37,7 @@ Copy files to/from a CVM via SCP
 | `-v, --verbose` | Show verbose SCP details |
 | `--dry-run` | Print SCP command without executing |
 
-### Global Options
+#### Global Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -50,7 +50,7 @@ Copy files to/from a CVM via SCP
 | `--profile PROFILE` | Temporarily use a different auth profile for this command |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
-### Examples
+#### Examples
 
 * Upload from phala.toml
 

--- a/phala-cloud/phala-cloud-cli/cvms.mdx
+++ b/phala-cloud/phala-cloud-cli/cvms.mdx
@@ -1,25 +1,26 @@
 ---
 title: "cvms"
 description: "Manage CVMs"
+hidden: true
 ---
 
 <Note>
 This command is marked as unstable and may change in future releases.
 </Note>
 
-## Command: `phala cvms`
+### Command: `phala cvms`
 
-### Syntax
+#### Syntax
 
 ```
 phala cvms <command> [options]
 ```
 
-### Description
+#### Description
 
 Manage CVMs
 
-### Global Options
+#### Global Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -32,6 +33,13 @@ Manage CVMs
 | `--profile PROFILE` | Temporarily use a different auth profile for this command |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
+#### Examples
+
+* Display help:
+
+```bash
+phala cvms --help
+```
 ### Subcommands
 
 | Command | Description |
@@ -57,10 +65,3 @@ Manage CVMs
 | `serial-logs` | Fetch VM serial console logs from a CVM |
 | `upgrade` | Upgrade a CVM to a new version (use "phala deploy" instead) |
 
-### Examples
-
-* Display help:
-
-```bash
-phala cvms --help
-```

--- a/phala-cloud/phala-cloud-cli/cvms/attestation.mdx
+++ b/phala-cloud/phala-cloud-cli/cvms/attestation.mdx
@@ -1,0 +1,54 @@
+---
+title: "cvms attestation"
+description: "Get CVM attestation"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala cvms attestation`
+
+### Syntax
+
+```
+phala cvms attestation [options] [<cvm_id>]
+```
+
+### Description
+
+Get CVM attestation
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<cvm_id>?` | CVM identifier (UUID, app_id, instance_id, or name) |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `-i, --interactive` | Enable interactive mode |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Show attestation summary
+
+```bash
+phala cvms attestation
+```
+
+* Output full attestation JSON
+
+```bash
+phala cvms attestation --json
+```
+

--- a/phala-cloud/phala-cloud-cli/cvms/create.mdx
+++ b/phala-cloud/phala-cloud-cli/cvms/create.mdx
@@ -1,0 +1,63 @@
+---
+title: "cvms create (Deprecated)"
+description: "Create a new CVM (use \"phala deploy\" instead)"
+---
+
+<Warning>
+This command is deprecated. See the newer alternatives.
+</Warning>
+
+## Command: `phala cvms create`
+
+### Syntax
+
+```
+phala cvms create [options]
+```
+
+### Description
+
+Create a new CVM (use "phala deploy" instead)
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-n, --name <value>` | Name of the CVM |
+| `-c, --compose <value>` | Path to Docker Compose file |
+| `--vcpu <value>` | Virtual CPUs (default: 1) |
+| `--memory <value>` | Memory in MB (default: 2048) |
+| `--disk-size <value>` | Disk size in GB (default: 40) |
+| `--teepod-id <value>` | TEEPod ID (auto-selected if omitted) |
+| `--image <value>` | dstack image version (uses default if omitted) |
+| `-e, --env-file <value>` | Path to environment file |
+| `--skip-env` | Skip env var prompt |
+| `--debug` | Enable debug output |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Create a CVM interactively
+
+```bash
+phala cvms create
+```
+
+* Create using predefined values
+
+```bash
+phala cvms create --name demo --compose ./docker-compose.yml
+```
+

--- a/phala-cloud/phala-cloud-cli/cvms/delete.mdx
+++ b/phala-cloud/phala-cloud-cli/cvms/delete.mdx
@@ -1,0 +1,73 @@
+---
+title: "cvms delete"
+description: "Delete a CVM"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala cvms delete`
+
+### Syntax
+
+```
+phala cvms delete [options] [<cvm_id>]
+```
+
+### Description
+
+Delete a CVM
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<cvm_id>?` | CVM identifier (UUID, app_id, instance_id, or name) |
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-f, --force` | Skip confirmation prompt |
+| `-y, --yes` | Alias for --force (skip confirmation prompt) |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `-i, --interactive` | Enable interactive mode |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Delete a CVM interactively
+
+```bash
+phala cvms delete
+```
+
+* Delete CVM by app_id
+
+```bash
+phala cvms delete app_123 --force
+```
+
+* Delete CVM by UUID
+
+```bash
+phala cvms delete 550e8400-e29b-41d4-a716-446655440000 -f
+```
+
+* Delete CVM by name
+
+```bash
+phala cvms delete my-app --yes
+```
+

--- a/phala-cloud/phala-cloud-cli/cvms/device-allowlist.mdx
+++ b/phala-cloud/phala-cloud-cli/cvms/device-allowlist.mdx
@@ -1,0 +1,48 @@
+---
+title: "cvms device-allowlist"
+description: "Show device allowlist status for a CVM's app"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala cvms device-allowlist`
+
+### Syntax
+
+```
+phala cvms device-allowlist [options] [<cvm_id>]
+```
+
+### Description
+
+Show device allowlist status for a CVM's app
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<cvm_id>?` | CVM identifier (UUID, app_id, instance_id, or name) |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `-i, --interactive` | Enable interactive mode |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Check device allowlist
+
+```bash
+phala cvms device-allowlist app_abc123
+```
+

--- a/phala-cloud/phala-cloud-cli/cvms/get.mdx
+++ b/phala-cloud/phala-cloud-cli/cvms/get.mdx
@@ -1,0 +1,66 @@
+---
+title: "cvms get"
+description: "Get details of a CVM"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala cvms get`
+
+### Syntax
+
+```
+phala cvms get [options] [<cvm_id>]
+```
+
+### Description
+
+Get details of a CVM
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<cvm_id>?` | CVM identifier (UUID, app_id, instance_id, or name) |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `-i, --interactive` | Enable interactive mode |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Get CVM interactively
+
+```bash
+phala cvms get
+```
+
+* By app_id
+
+```bash
+phala cvms get app_abc123
+```
+
+* By UUID
+
+```bash
+phala cvms get 550e8400-e29b-41d4-a716-446655440000
+```
+
+* By name
+
+```bash
+phala cvms get my-app
+```
+

--- a/phala-cloud/phala-cloud-cli/cvms/list-nodes.mdx
+++ b/phala-cloud/phala-cloud-cli/cvms/list-nodes.mdx
@@ -1,0 +1,41 @@
+---
+title: "cvms list-nodes"
+description: "List worker nodes"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala cvms list-nodes`
+
+### Syntax
+
+```
+phala cvms list-nodes
+```
+
+### Description
+
+List worker nodes
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Display help:
+
+```bash
+phala cvms list-nodes --help
+```

--- a/phala-cloud/phala-cloud-cli/cvms/list.mdx
+++ b/phala-cloud/phala-cloud-cli/cvms/list.mdx
@@ -1,0 +1,81 @@
+---
+title: "cvms list"
+description: "List CVMs"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala cvms list`
+
+### Syntax
+
+```
+phala cvms list [options]
+```
+
+### Description
+
+List CVMs
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `--page <value>` | Page number (1-based) |
+| `--page-size <value>` | Number of items per page |
+| `--search <value>` | Search by name, app_id, vm_uuid, or instance_id |
+| `--status <value>` | Filter by CVM status (can be specified multiple times) |
+| `--listed, --no-listed` | Filter by listed status |
+| `--base-image <value>` | Filter by base image name |
+| `--instance-type <value>` | Filter by instance type |
+| `--kms-type <value>` | Filter by KMS type |
+| `--node <value>` | Filter by node name |
+| `--region <value>` | Filter by region identifier |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* List CVMs
+
+```bash
+phala cvms ls
+```
+
+* Second page
+
+```bash
+phala cvms ls --page 2
+```
+
+* Search by name
+
+```bash
+phala cvms ls --search my-cvm
+```
+
+* Filter by status
+
+```bash
+phala cvms ls --status running
+```
+
+* Output as JSON
+
+```bash
+phala cvms ls --json
+```
+

--- a/phala-cloud/phala-cloud-cli/cvms/logs.mdx
+++ b/phala-cloud/phala-cloud-cli/cvms/logs.mdx
@@ -1,0 +1,81 @@
+---
+title: "cvms logs (Deprecated)"
+description: "Fetch container logs from a CVM"
+---
+
+<Warning>
+This command is deprecated. See the newer alternatives.
+</Warning>
+
+## Command: `phala cvms logs`
+
+### Syntax
+
+```
+phala cvms logs [options] [<cvm_id>]
+```
+
+### Description
+
+Fetch container logs from a CVM
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<cvm_id>?` | CVM identifier (UUID, app_id, instance_id, or name) |
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-n, --tail <value>` | Lines from end |
+| `-f, --follow` | Stream logs in real-time |
+| `-t, --timestamps` | Show timestamps |
+| `-c, --container <value>` | Container name or ID (defaults to first) |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `-i, --interactive` | Enable interactive mode |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Show container logs from a CVM
+
+```bash
+phala cvms logs app_abc123
+```
+
+* Show last 100 lines of logs
+
+```bash
+phala cvms logs app_abc123 --tail 100
+```
+
+* Follow logs in real-time
+
+```bash
+phala cvms logs app_abc123 --follow
+```
+
+* Show logs from a specific container
+
+```bash
+phala cvms logs app_abc123 --container my-service
+```
+
+* Show logs with timestamps
+
+```bash
+phala cvms logs app_abc123 --timestamps
+```
+

--- a/phala-cloud/phala-cloud-cli/cvms/replicate.mdx
+++ b/phala-cloud/phala-cloud-cli/cvms/replicate.mdx
@@ -1,0 +1,79 @@
+---
+title: "cvms replicate"
+description: "Create a replica of an existing CVM"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala cvms replicate`
+
+### Syntax
+
+```
+phala cvms replicate [options] [<cvm_id>]
+```
+
+### Description
+
+Create a replica of an existing CVM
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<cvm_id>?` | CVM identifier (UUID, app_id, instance_id, or name) |
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `--node-id <value>, --teepod-id <value>` | Target node ID for the replica. |
+| `--compose-hash <value>` | Compose hash to replicate. Required when the source app has multiple live instances. |
+| `-e, --env-file <value>` | Path to environment file. |
+
+### Advanced Options
+
+| Option | Description |
+| ------ | ----------- |
+| `--private-key <value>` | Private key for signing on-chain transactions (or set PRIVATE_KEY env var) |
+| `--rpc-url <value>` | RPC URL for on-chain KMS transactions (or set ETH_RPC_URL env var) |
+| `--prepare-only` | Prepare the replica and generate a commit token. Skips all on-chain operations. |
+| `--commit` | Commit a previously prepared replica using a commit token. Requires --token, --compose-hash, and --transaction-hash. |
+| `--token <value>` | Commit token from a prepare-only replica request. |
+| `--transaction-hash <value>` | Transaction hash proving on-chain compose hash registration. Pass `already-registered` to skip the proof and rely on state-only verification. |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `-i, --interactive` | Enable interactive mode |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Replicate a CVM
+
+```bash
+phala cvms replicate 1234 --node-id 5
+```
+
+* Prepare a replica for multisig approval
+
+```bash
+phala cvms replicate 1234 --node-id 5 --compose-hash <hash> --prepare-only
+```
+
+* Commit a prepared replica
+
+```bash
+phala cvms replicate 1234 --commit --token <token> --compose-hash <hash> --transaction-hash <tx-hash>
+```
+

--- a/phala-cloud/phala-cloud-cli/cvms/resize.mdx
+++ b/phala-cloud/phala-cloud-cli/cvms/resize.mdx
@@ -1,0 +1,64 @@
+---
+title: "cvms resize"
+description: "Resize resources for a CVM"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala cvms resize`
+
+### Syntax
+
+```
+phala cvms resize [options] [<cvm_id>]
+```
+
+### Description
+
+Resize resources for a CVM
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<cvm_id>?` | CVM identifier (UUID, app_id, instance_id, or name) |
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-v, --vcpu <value>` | Virtual CPUs |
+| `-m, --memory <value>` | Memory in MB |
+| `-d, --disk-size <value>` | Disk size in GB |
+| `-r, --allow-restart <value>` | Allow CVM restart |
+| `-y, --yes` | Skip confirmation |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `--version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `--json` | Output in JSON format |
+| `-i, --interactive` | Enable interactive mode |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Resize CVM interactively
+
+```bash
+phala cvms resize
+```
+
+* Resize without confirmation
+
+```bash
+phala cvms resize app_123 --vcpu 4 --memory 4096 --disk-size 120 --yes
+```
+

--- a/phala-cloud/phala-cloud-cli/cvms/restart.mdx
+++ b/phala-cloud/phala-cloud-cli/cvms/restart.mdx
@@ -1,0 +1,56 @@
+---
+title: "cvms restart"
+description: "Restart a CVM"
+---
+
+## Command: `phala cvms restart`
+
+### Syntax
+
+```
+phala cvms restart [options] [<cvm_id>]
+```
+
+### Description
+
+Restart a CVM
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<cvm_id>?` | CVM identifier (UUID, app_id, instance_id, or name) |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `-i, --interactive` | Enable interactive mode |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* By app_id
+
+```bash
+phala cvms restart app_123
+```
+
+* By UUID
+
+```bash
+phala cvms restart 550e8400-e29b-41d4-a716-446655440000
+```
+
+* By name
+
+```bash
+phala cvms restart my-app
+```
+

--- a/phala-cloud/phala-cloud-cli/cvms/serial-logs.mdx
+++ b/phala-cloud/phala-cloud-cli/cvms/serial-logs.mdx
@@ -1,0 +1,74 @@
+---
+title: "cvms serial-logs (Deprecated)"
+description: "Fetch VM serial console logs from a CVM"
+---
+
+<Warning>
+This command is deprecated. See the newer alternatives.
+</Warning>
+
+## Command: `phala cvms serial-logs`
+
+### Syntax
+
+```
+phala cvms serial-logs [options] [<cvm_id>]
+```
+
+### Description
+
+Fetch VM serial console logs from a CVM
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<cvm_id>?` | CVM identifier (UUID, app_id, instance_id, or name) |
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-n, --tail <value>` | Lines from end |
+| `-f, --follow` | Stream logs in real-time |
+| `-t, --timestamps` | Show timestamps |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `-i, --interactive` | Enable interactive mode |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Show VM serial logs
+
+```bash
+phala cvms serial-logs app_abc123
+```
+
+* Show last 100 lines of serial logs
+
+```bash
+phala cvms serial-logs app_abc123 --tail 100
+```
+
+* Follow serial logs in real-time
+
+```bash
+phala cvms serial-logs app_abc123 --follow
+```
+
+* Show serial logs with timestamps
+
+```bash
+phala cvms serial-logs app_abc123 --timestamps
+```
+

--- a/phala-cloud/phala-cloud-cli/cvms/start.mdx
+++ b/phala-cloud/phala-cloud-cli/cvms/start.mdx
@@ -1,0 +1,56 @@
+---
+title: "cvms start"
+description: "Start a stopped CVM"
+---
+
+## Command: `phala cvms start`
+
+### Syntax
+
+```
+phala cvms start [options] [<cvm_id>]
+```
+
+### Description
+
+Start a stopped CVM
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<cvm_id>?` | CVM identifier (UUID, app_id, instance_id, or name) |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `-i, --interactive` | Enable interactive mode |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Start CVM by app_id
+
+```bash
+phala cvms start app_123
+```
+
+* Start CVM by UUID
+
+```bash
+phala cvms start 550e8400-e29b-41d4-a716-446655440000
+```
+
+* Start CVM by name
+
+```bash
+phala cvms start my-app
+```
+

--- a/phala-cloud/phala-cloud-cli/cvms/stop.mdx
+++ b/phala-cloud/phala-cloud-cli/cvms/stop.mdx
@@ -1,0 +1,56 @@
+---
+title: "cvms stop"
+description: "Stop a running CVM"
+---
+
+## Command: `phala cvms stop`
+
+### Syntax
+
+```
+phala cvms stop [options] [<cvm_id>]
+```
+
+### Description
+
+Stop a running CVM
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<cvm_id>?` | CVM identifier (UUID, app_id, instance_id, or name) |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `-i, --interactive` | Enable interactive mode |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Stop CVM by app_id
+
+```bash
+phala cvms stop app_123
+```
+
+* Stop CVM by UUID
+
+```bash
+phala cvms stop 550e8400-e29b-41d4-a716-446655440000
+```
+
+* Stop CVM by name
+
+```bash
+phala cvms stop my-app
+```
+

--- a/phala-cloud/phala-cloud-cli/cvms/upgrade.mdx
+++ b/phala-cloud/phala-cloud-cli/cvms/upgrade.mdx
@@ -1,0 +1,62 @@
+---
+title: "cvms upgrade (Deprecated)"
+description: "Upgrade a CVM to a new version (use \"phala deploy\" instead)"
+---
+
+<Warning>
+This command is deprecated. See the newer alternatives.
+</Warning>
+
+## Command: `phala cvms upgrade`
+
+### Syntax
+
+```
+phala cvms upgrade [options] [<cvm_id>]
+```
+
+### Description
+
+Upgrade a CVM to a new version (use "phala deploy" instead)
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<cvm_id>?` | CVM identifier (UUID, app_id, instance_id, or name) |
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-c, --compose <value>` | Path to Docker Compose file |
+| `-e, --env-file <value>` | Path to environment file |
+| `--debug` | Enable debug output |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `-i, --interactive` | Enable interactive mode |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Upgrade a CVM interactively
+
+```bash
+phala cvms upgrade
+```
+
+* Upgrade using a compose file
+
+```bash
+phala cvms upgrade app_123 --compose ./docker-compose.yml
+```
+

--- a/phala-cloud/phala-cloud-cli/deploy.mdx
+++ b/phala-cloud/phala-cloud-cli/deploy.mdx
@@ -3,19 +3,19 @@ title: "deploy"
 description: "Deploy new CVM or update existing one"
 ---
 
-## Command: `phala deploy`
+### Command: `phala deploy`
 
-### Syntax
+#### Syntax
 
 ```
 phala deploy [options]
 ```
 
-### Description
+#### Description
 
 Deploy new CVM or update existing one
 
-### Options
+#### Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -32,7 +32,7 @@ Deploy new CVM or update existing one
 | `--public-sysinfo, --no-public-sysinfo` | Make CVM system info publicly accessible (default: true) |
 | `--listed, --no-listed` | List CVM on the public Trust Center (default: false) |
 
-### Advanced Options
+#### Advanced Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -52,7 +52,7 @@ Deploy new CVM or update existing one
 | `--compose-hash <value>` | Compose hash from a prepare-only update. Optional in --commit mode when the token can provide it. |
 | `--transaction-hash <value>` | Transaction hash proving on-chain compose hash registration. Pass `already-registered` to skip the proof and rely on state-only verification. |
 
-### Deprecated Options
+#### Deprecated Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -62,7 +62,7 @@ Deploy new CVM or update existing one
 | `--env-file <value>` | Use -e instead |
 | `--kms-id <value>` | Use --kms instead |
 
-### Global Options
+#### Global Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -75,7 +75,7 @@ Deploy new CVM or update existing one
 | `--profile PROFILE` | Temporarily use a different auth profile for this command |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
-### Examples
+#### Examples
 
 * Deploy new CVM
 

--- a/phala-cloud/phala-cloud-cli/docker.mdx
+++ b/phala-cloud/phala-cloud-cli/docker.mdx
@@ -1,25 +1,26 @@
 ---
 title: "docker (Deprecated)"
 description: "Docker Hub login and image management"
+hidden: true
 ---
 
 <Warning>
 This command is deprecated. See the newer alternatives.
 </Warning>
 
-## Command: `phala docker`
+### Command: `phala docker`
 
-### Syntax
+#### Syntax
 
 ```
 phala docker <command> [options]
 ```
 
-### Description
+#### Description
 
 Docker Hub login and image management
 
-### Global Options
+#### Global Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -32,6 +33,13 @@ Docker Hub login and image management
 | `--profile PROFILE` | Temporarily use a different auth profile for this command |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
+#### Examples
+
+* Display help:
+
+```bash
+phala docker --help
+```
 ### Subcommands
 
 | Command | Description |
@@ -42,10 +50,3 @@ Docker Hub login and image management
 | `generate` | Generate a Docker Compose file |
 | `run` | Run a Docker Compose setup |
 
-### Examples
-
-* Display help:
-
-```bash
-phala docker --help
-```

--- a/phala-cloud/phala-cloud-cli/docker/build.mdx
+++ b/phala-cloud/phala-cloud-cli/docker/build.mdx
@@ -1,0 +1,56 @@
+---
+title: "docker build"
+description: "Build a Docker image"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala docker build`
+
+### Syntax
+
+```
+phala docker build [options]
+```
+
+### Description
+
+Build a Docker image
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-i, --image <value>` | Image name |
+| `-t, --tag <value>` | Image tag |
+| `-f, --file <value>` | Path to Dockerfile |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Build docker image with prompts
+
+```bash
+phala docker build
+```
+
+* Build docker image with options
+
+```bash
+phala docker build --image myapp --tag latest
+```
+

--- a/phala-cloud/phala-cloud-cli/docker/generate.mdx
+++ b/phala-cloud/phala-cloud-cli/docker/generate.mdx
@@ -1,0 +1,50 @@
+---
+title: "docker generate"
+description: "Generate a Docker Compose file"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala docker generate`
+
+### Syntax
+
+```
+phala docker generate [options]
+```
+
+### Description
+
+Generate a Docker Compose file
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-i, --image <value>` | Docker image name (e.g. phala/phala-cloud) |
+| `-e, --env-file <value>` | Path to env file |
+| `-o, --output <value>` | Output path for docker-compose.yml |
+| `--template <value>` | Template for docker-compose.yml |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Display help:
+
+```bash
+phala docker generate --help
+```

--- a/phala-cloud/phala-cloud-cli/docker/login.mdx
+++ b/phala-cloud/phala-cloud-cli/docker/login.mdx
@@ -1,0 +1,49 @@
+---
+title: "docker login"
+description: "Login to Docker Hub"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala docker login`
+
+### Syntax
+
+```
+phala docker login [options]
+```
+
+### Description
+
+Login to Docker Hub
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-u, --username <value>` | Docker Hub username |
+| `-p, --password <value>` | Docker Hub password |
+| `-r, --registry <value>` | Docker registry URL |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Display help:
+
+```bash
+phala docker login --help
+```

--- a/phala-cloud/phala-cloud-cli/docker/push.mdx
+++ b/phala-cloud/phala-cloud-cli/docker/push.mdx
@@ -1,0 +1,47 @@
+---
+title: "docker push"
+description: "Push a Docker image to Docker Hub"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala docker push`
+
+### Syntax
+
+```
+phala docker push [options]
+```
+
+### Description
+
+Push a Docker image to Docker Hub
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-i, --image <value>` | Full image name (e.g. username/image:tag) |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Display help:
+
+```bash
+phala docker push --help
+```

--- a/phala-cloud/phala-cloud-cli/docker/run.mdx
+++ b/phala-cloud/phala-cloud-cli/docker/run.mdx
@@ -1,0 +1,49 @@
+---
+title: "docker run"
+description: "Run a Docker Compose setup"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala docker run`
+
+### Syntax
+
+```
+phala docker run [options]
+```
+
+### Description
+
+Run a Docker Compose setup
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-c, --compose <value>` | Path to docker-compose.yml file |
+| `-e, --env-file <value>` | Path to environment variables file |
+| `--skip-env` | Skip env file prompt |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Display help:
+
+```bash
+phala docker run --help
+```

--- a/phala-cloud/phala-cloud-cli/envs.mdx
+++ b/phala-cloud/phala-cloud-cli/envs.mdx
@@ -1,21 +1,22 @@
 ---
 title: "envs"
 description: "Encrypt and update CVM sealed environment variables"
+hidden: true
 ---
 
-## Command: `phala envs`
+### Command: `phala envs`
 
-### Syntax
+#### Syntax
 
 ```
 phala envs <command> [options]
 ```
 
-### Description
+#### Description
 
 Encrypt and update CVM sealed environment variables
 
-### Global Options
+#### Global Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -28,6 +29,13 @@ Encrypt and update CVM sealed environment variables
 | `--profile PROFILE` | Temporarily use a different auth profile for this command |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
+#### Examples
+
+* Display help:
+
+```bash
+phala envs --help
+```
 ### Subcommands
 
 | Command | Description |
@@ -35,10 +43,3 @@ Encrypt and update CVM sealed environment variables
 | `encrypt` | Encrypt environment variables for a CVM (sealed, only readable inside TEE) |
 | `update` | Encrypt and push sealed environment variables to a CVM (only readable inside TEE) |
 
-### Examples
-
-* Display help:
-
-```bash
-phala envs --help
-```

--- a/phala-cloud/phala-cloud-cli/envs/encrypt.mdx
+++ b/phala-cloud/phala-cloud-cli/envs/encrypt.mdx
@@ -1,0 +1,75 @@
+---
+title: "envs encrypt"
+description: "Encrypt environment variables for a CVM (sealed, only readable inside TEE)"
+---
+
+## Command: `phala envs encrypt`
+
+### Syntax
+
+```
+phala envs encrypt [options] [<cvm_id>]
+```
+
+### Description
+
+Encrypt environment variables for a CVM (sealed, only readable inside TEE)
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<cvm_id>?` | CVM identifier (UUID, app_id, instance_id, or name) |
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-e, --env <value>` | Environment variable (KEY=VALUE) or env file path (repeatable) |
+| `-n, --no-newline` | Do not print trailing newline (useful for piping) |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `-i, --interactive` | Enable interactive mode |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Encrypt inline variables
+
+```bash
+phala envs encrypt app_abc123 -e SECRET=value -e API_KEY=xxx
+```
+
+* Encrypt from env file
+
+```bash
+phala envs encrypt app_abc123 -e .env
+```
+
+* Encrypt with CVM from phala.toml
+
+```bash
+phala envs encrypt -e .env.production
+```
+
+* Pipe to file for later use
+
+```bash
+phala envs encrypt app_abc123 -e .env > encrypted.hex
+```
+
+* Pipe without trailing newline
+
+```bash
+phala envs encrypt app_abc123 -n -e .env | some-tool
+```
+

--- a/phala-cloud/phala-cloud-cli/envs/update.mdx
+++ b/phala-cloud/phala-cloud-cli/envs/update.mdx
@@ -1,0 +1,82 @@
+---
+title: "envs update"
+description: "Encrypt and push sealed environment variables to a CVM (only readable inside TEE)"
+---
+
+## Command: `phala envs update`
+
+### Syntax
+
+```
+phala envs update [options] [<cvm_id>]
+```
+
+### Description
+
+Encrypt and push sealed environment variables to a CVM (only readable inside TEE)
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<cvm_id>?` | CVM identifier (UUID, app_id, instance_id, or name) |
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-e, --env <value>` | Environment variable (KEY=VALUE) or env file path (repeatable) |
+| `--encrypted-env <value>` | Pre-encrypted environment variables as hex string (from 'phala envs encrypt') |
+
+### Advanced Options
+
+| Option | Description |
+| ------ | ----------- |
+| `--private-key <value>` | Private key for signing on-chain transactions (or set PRIVATE_KEY env var) |
+| `--rpc-url <value>` | RPC URL for on-chain KMS transactions (or set ETH_RPC_URL env var) |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `-i, --interactive` | Enable interactive mode |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Update with inline variables
+
+```bash
+phala envs update app_abc123 -e SECRET=newvalue -e API_KEY=xxx
+```
+
+* Update from env file
+
+```bash
+phala envs update app_abc123 -e .env.production
+```
+
+* Update with CVM from phala.toml
+
+```bash
+phala envs update -e .env
+```
+
+* Update with pre-encrypted hex (from 'phala envs encrypt')
+
+```bash
+phala envs update app_abc123 --encrypted-env $(phala envs encrypt app_abc123 -e .env)
+```
+
+* Update with on-chain KMS
+
+```bash
+phala envs update app_abc123 -e .env --private-key <key>
+```
+

--- a/phala-cloud/phala-cloud-cli/instance-types.mdx
+++ b/phala-cloud/phala-cloud-cli/instance-types.mdx
@@ -7,25 +7,25 @@ description: "List available instance types"
 This command is marked as unstable and may change in future releases.
 </Note>
 
-## Command: `phala instance-types`
+### Command: `phala instance-types`
 
-### Syntax
+#### Syntax
 
 ```
 phala instance-types [options] [<family>]
 ```
 
-### Description
+#### Description
 
 List available instance types
 
-### Arguments
+#### Arguments
 
 | Argument | Description |
 | -------- | ----------- |
 | `<family>?` | Instance type family (cpu, gpu) |
 
-### Global Options
+#### Global Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -38,7 +38,7 @@ List available instance types
 | `--profile PROFILE` | Temporarily use a different auth profile for this command |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
-### Examples
+#### Examples
 
 * List all instance type families
 

--- a/phala-cloud/phala-cloud-cli/instances.mdx
+++ b/phala-cloud/phala-cloud-cli/instances.mdx
@@ -1,0 +1,50 @@
+---
+title: "instances"
+description: "Manage app instances"
+hidden: true
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+### Command: `phala instances`
+
+#### Syntax
+
+```
+phala instances <command> [options]
+```
+
+#### Description
+
+Manage app instances
+
+#### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+#### Examples
+
+* Display help:
+
+```bash
+phala instances --help
+```
+### Subcommands
+
+| Command | Description |
+| ------- | ----------- |
+| `ls` | List instances of an app |
+| `add` | Create a new instance under an existing app |
+| `rm` | Delete one or more app instances by VM UUID |
+

--- a/phala-cloud/phala-cloud-cli/instances/add.mdx
+++ b/phala-cloud/phala-cloud-cli/instances/add.mdx
@@ -1,0 +1,82 @@
+---
+title: "instances add"
+description: "Create a new instance under an existing app"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala instances add`
+
+### Syntax
+
+```
+phala instances add [options]
+```
+
+### Description
+
+Create a new instance under an existing app
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `--app-id <value>` | App ID (hex identifier). Defaults to app_id in phala.toml. |
+| `--node-id <value>, --teepod-id <value>` | Target node ID for the new instance. |
+| `-c, --compose-file <value>` | Path to Docker Compose file. |
+| `--pre-launch-script <value>` | Path to pre-launch script file. |
+| `-e, --env-file <value>` | Path to environment file. |
+| `--compose-hash <value>` | Compose hash to use (existing revision). |
+
+### Advanced Options
+
+| Option | Description |
+| ------ | ----------- |
+| `--private-key <value>` | Private key for signing on-chain transactions (or set PRIVATE_KEY env var) |
+| `--rpc-url <value>` | RPC URL for on-chain KMS transactions (or set ETH_RPC_URL env var) |
+| `--prepare-only` | Prepare the instance and generate a commit token. Skips all on-chain operations. |
+| `--commit` | Commit a previously prepared instance using a commit token. Requires --token, --compose-hash, and --transaction-hash. |
+| `--token <value>` | Commit token from a prepare-only request. |
+| `--transaction-hash <value>` | Transaction hash proving on-chain compose hash registration. Pass `already-registered` to skip the proof and rely on state-only verification. |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `-i, --interactive` | Enable interactive mode |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Add instance with existing compose
+
+```bash
+phala instances add --app-id <app-id> --node-id 5
+```
+
+* Add instance with new Docker Compose
+
+```bash
+phala instances add --app-id <app-id> --node-id 5 --compose-file docker-compose.yml
+```
+
+* Prepare for multisig approval
+
+```bash
+phala instances add --app-id <app-id> --node-id 5 --compose-file docker-compose.yml --prepare-only
+```
+
+* Commit a prepared instance
+
+```bash
+phala instances add --app-id <app-id> --commit --token <token> --compose-hash <hash> --transaction-hash <tx-hash>
+```
+

--- a/phala-cloud/phala-cloud-cli/instances/ls.mdx
+++ b/phala-cloud/phala-cloud-cli/instances/ls.mdx
@@ -1,0 +1,60 @@
+---
+title: "instances ls"
+description: "List instances of an app"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala instances ls`
+
+### Syntax
+
+```
+phala instances ls [options]
+```
+
+### Description
+
+List instances of an app
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `--app-id <value>` | App ID (hex identifier). Defaults to app_id in phala.toml. |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* List instances for app in phala.toml
+
+```bash
+phala instances ls
+```
+
+* List instances for a specific app
+
+```bash
+phala instances ls --app-id <app-id>
+```
+
+* Output as JSON
+
+```bash
+phala instances ls --app-id <app-id> --json
+```
+

--- a/phala-cloud/phala-cloud-cli/instances/rm.mdx
+++ b/phala-cloud/phala-cloud-cli/instances/rm.mdx
@@ -1,0 +1,67 @@
+---
+title: "instances rm"
+description: "Delete one or more app instances by VM UUID"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala instances rm`
+
+### Syntax
+
+```
+phala instances rm [options] <vm_uuid...>...
+```
+
+### Description
+
+Delete one or more app instances by VM UUID
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<vm_uuid......>` | VM UUID(s) of the instances to delete |
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-f, --force` | Skip confirmation prompt |
+| `-y, --yes` | Alias for --force (skip confirmation prompt) |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Delete a single instance
+
+```bash
+phala instances rm 550e8400-e29b-41d4-a716-446655440000
+```
+
+* Delete multiple instances
+
+```bash
+phala instances rm 550e8400-e29b-41d4-a716-446655440000 661f9511-f30c-52e5-b827-557766551111
+```
+
+* Delete without confirmation
+
+```bash
+phala instances rm 550e8400-e29b-41d4-a716-446655440000 --force
+```
+

--- a/phala-cloud/phala-cloud-cli/kms.mdx
+++ b/phala-cloud/phala-cloud-cli/kms.mdx
@@ -1,25 +1,26 @@
 ---
 title: "kms"
 description: "Manage on-chain KMS contracts"
+hidden: true
 ---
 
 <Note>
 This command is marked as unstable and may change in future releases.
 </Note>
 
-## Command: `phala kms`
+### Command: `phala kms`
 
-### Syntax
+#### Syntax
 
 ```
 phala kms <command> [options]
 ```
 
-### Description
+#### Description
 
 Manage on-chain KMS contracts
 
-### Global Options
+#### Global Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -32,6 +33,13 @@ Manage on-chain KMS contracts
 | `--profile PROFILE` | Temporarily use a different auth profile for this command |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
+#### Examples
+
+* Display help:
+
+```bash
+phala kms --help
+```
 ### Subcommands
 
 | Command | Description |
@@ -40,10 +48,3 @@ Manage on-chain KMS contracts
 | `ethereum` | Show on-chain KMS details for ethereum |
 | `base` | Show on-chain KMS details for base |
 
-### Examples
-
-* Display help:
-
-```bash
-phala kms --help
-```

--- a/phala-cloud/phala-cloud-cli/kms/base.mdx
+++ b/phala-cloud/phala-cloud-cli/kms/base.mdx
@@ -1,0 +1,48 @@
+---
+title: "kms base"
+description: "Show on-chain KMS details for base"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala kms base`
+
+### Syntax
+
+```
+phala kms base [options]
+```
+
+### Description
+
+Show on-chain KMS details for base
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Show base KMS details
+
+```bash
+phala kms base
+```
+
+* Output as JSON
+
+```bash
+phala kms base --json
+```
+

--- a/phala-cloud/phala-cloud-cli/kms/ethereum.mdx
+++ b/phala-cloud/phala-cloud-cli/kms/ethereum.mdx
@@ -1,0 +1,48 @@
+---
+title: "kms ethereum"
+description: "Show on-chain KMS details for ethereum"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala kms ethereum`
+
+### Syntax
+
+```
+phala kms ethereum [options]
+```
+
+### Description
+
+Show on-chain KMS details for ethereum
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Show ethereum KMS details
+
+```bash
+phala kms ethereum
+```
+
+* Output as JSON
+
+```bash
+phala kms ethereum --json
+```
+

--- a/phala-cloud/phala-cloud-cli/kms/list.mdx
+++ b/phala-cloud/phala-cloud-cli/kms/list.mdx
@@ -1,0 +1,48 @@
+---
+title: "kms list"
+description: "List on-chain KMS contracts"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala kms list`
+
+### Syntax
+
+```
+phala kms list [options]
+```
+
+### Description
+
+List on-chain KMS contracts
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* List on-chain KMS
+
+```bash
+phala kms list
+```
+
+* Output as JSON
+
+```bash
+phala kms list --json
+```
+

--- a/phala-cloud/phala-cloud-cli/link.mdx
+++ b/phala-cloud/phala-cloud-cli/link.mdx
@@ -17,7 +17,11 @@ phala link [options] [<cvm-id>]
 
 ### Description
 
-Link a local directory to a CVM
+Link a local directory to a CVM.
+
+<Note>
+As of v1.1.18, `phala link` supports linking by a 40-character hex <code>app_id</code> (resolved via the <code>/apps/{app_id}</code> endpoint). After authentication, the CLI prints the workspace <code>name</code> and <code>slug</code> so you can confirm the target context before the link is written.
+</Note>
 
 ### Arguments
 

--- a/phala-cloud/phala-cloud-cli/login.mdx
+++ b/phala-cloud/phala-cloud-cli/login.mdx
@@ -3,25 +3,25 @@ title: "login"
 description: "Authenticate with Phala Cloud"
 ---
 
-## Command: `phala login`
+### Command: `phala login`
 
-### Syntax
+#### Syntax
 
 ```
 phala login [options] [<api-key>]
 ```
 
-### Description
+#### Description
 
 Authenticate with Phala Cloud
 
-### Arguments
+#### Arguments
 
 | Argument | Description |
 | -------- | ----------- |
 | `<api-key>?` | API key (triggers device flow if omitted) |
 
-### Options
+#### Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -31,7 +31,7 @@ Authenticate with Phala Cloud
 | `--print-token` | Print token to stdout without saving |
 | `--url <value>` | Custom API endpoint URL |
 
-### Global Options
+#### Global Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -43,7 +43,7 @@ Authenticate with Phala Cloud
 | `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
-### Examples
+#### Examples
 
 * Display help:
 

--- a/phala-cloud/phala-cloud-cli/logout.mdx
+++ b/phala-cloud/phala-cloud-cli/logout.mdx
@@ -3,19 +3,19 @@ title: "logout"
 description: "Remove stored API key"
 ---
 
-## Command: `phala logout`
+### Command: `phala logout`
 
-### Syntax
+#### Syntax
 
 ```
 phala logout
 ```
 
-### Description
+#### Description
 
 Remove stored API key
 
-### Global Options
+#### Global Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -28,7 +28,7 @@ Remove stored API key
 | `--profile PROFILE` | Temporarily use a different auth profile for this command |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
-### Examples
+#### Examples
 
 * Display help:
 

--- a/phala-cloud/phala-cloud-cli/logs.mdx
+++ b/phala-cloud/phala-cloud-cli/logs.mdx
@@ -7,25 +7,25 @@ description: "Fetch logs from a CVM"
 This command is marked as unstable and may change in future releases.
 </Note>
 
-## Command: `phala logs`
+### Command: `phala logs`
 
-### Syntax
+#### Syntax
 
 ```
 phala logs [options] [<container-name>]
 ```
 
-### Description
+#### Description
 
 Fetch logs from a CVM
 
-### Arguments
+#### Arguments
 
 | Argument | Description |
 | -------- | ----------- |
 | `<container-name>?` | Container name to fetch logs from |
 
-### Options
+#### Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -39,7 +39,7 @@ Fetch logs from a CVM
 | `--since SINCE` | Start time (RFC3339 or relative, e.g. 42m) |
 | `--until UNTIL` | End time (RFC3339 or relative) |
 
-### Global Options
+#### Global Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -52,7 +52,7 @@ Fetch logs from a CVM
 | `--profile PROFILE` | Temporarily use a different auth profile for this command |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
-### Examples
+#### Examples
 
 * Container stdout
 

--- a/phala-cloud/phala-cloud-cli/nodes.mdx
+++ b/phala-cloud/phala-cloud-cli/nodes.mdx
@@ -1,25 +1,26 @@
 ---
 title: "nodes"
 description: "Manage TEE nodes"
+hidden: true
 ---
 
 <Note>
 This command is marked as unstable and may change in future releases.
 </Note>
 
-## Command: `phala nodes`
+### Command: `phala nodes`
 
-### Syntax
+#### Syntax
 
 ```
 phala nodes <command> [options]
 ```
 
-### Description
+#### Description
 
 Manage TEE nodes
 
-### Global Options
+#### Global Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -32,16 +33,16 @@ Manage TEE nodes
 | `--profile PROFILE` | Temporarily use a different auth profile for this command |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
-### Subcommands
-
-| Command | Description |
-| ------- | ----------- |
-| `list` | List workspace nodes |
-
-### Examples
+#### Examples
 
 * Display help:
 
 ```bash
 phala nodes --help
 ```
+### Subcommands
+
+| Command | Description |
+| ------- | ----------- |
+| `list` | List workspace nodes |
+

--- a/phala-cloud/phala-cloud-cli/nodes/list.mdx
+++ b/phala-cloud/phala-cloud-cli/nodes/list.mdx
@@ -1,0 +1,61 @@
+---
+title: "nodes list"
+description: "List workspace nodes"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala nodes list`
+
+### Syntax
+
+```
+phala nodes list [options]
+```
+
+### Description
+
+List workspace nodes
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `--page <value>` | Page number (1-based) |
+| `--page-size <value>` | Number of items per page |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* List nodes (page 1)
+
+```bash
+phala nodes list
+```
+
+* List nodes (page 2)
+
+```bash
+phala nodes list --page 2
+```
+
+* Output as JSON
+
+```bash
+phala nodes list --json
+```
+

--- a/phala-cloud/phala-cloud-cli/os-images.mdx
+++ b/phala-cloud/phala-cloud-cli/os-images.mdx
@@ -7,19 +7,19 @@ description: "List available OS images"
 This command is marked as unstable and may change in future releases.
 </Note>
 
-## Command: `phala os-images`
+### Command: `phala os-images`
 
-### Syntax
+#### Syntax
 
 ```
 phala os-images [options]
 ```
 
-### Description
+#### Description
 
 List available OS images
 
-### Options
+#### Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -29,7 +29,7 @@ List available OS images
 | `--page-size <value>` | Items per page (max 100) |
 | `--all` | Fetch all pages |
 
-### Global Options
+#### Global Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -42,7 +42,7 @@ List available OS images
 | `--profile PROFILE` | Temporarily use a different auth profile for this command |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
-### Examples
+#### Examples
 
 * List all OS images
 

--- a/phala-cloud/phala-cloud-cli/profiles.mdx
+++ b/phala-cloud/phala-cloud-cli/profiles.mdx
@@ -1,21 +1,22 @@
 ---
 title: "profiles"
 description: "List auth profiles"
+hidden: true
 ---
 
-## Command: `phala profiles`
+### Command: `phala profiles`
 
-### Syntax
+#### Syntax
 
 ```
 phala profiles
 ```
 
-### Description
+#### Description
 
 List auth profiles
 
-### Global Options
+#### Global Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -28,6 +29,13 @@ List auth profiles
 | `--profile PROFILE` | Temporarily use a different auth profile for this command |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
+#### Examples
+
+* Display help:
+
+```bash
+phala profiles --help
+```
 ### Subcommands
 
 | Command | Description |
@@ -36,10 +44,3 @@ List auth profiles
 | `rename` | Rename an auth profile |
 | `delete` | Delete an auth profile |
 
-### Examples
-
-* Display help:
-
-```bash
-phala profiles --help
-```

--- a/phala-cloud/phala-cloud-cli/profiles/delete.mdx
+++ b/phala-cloud/phala-cloud-cli/profiles/delete.mdx
@@ -1,0 +1,43 @@
+---
+title: "profiles delete"
+description: "Delete an auth profile"
+---
+
+## Command: `phala profiles delete`
+
+### Syntax
+
+```
+phala profiles delete <profile-name>
+```
+
+### Description
+
+Delete an auth profile
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<profile-name>` | Profile name |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Display help:
+
+```bash
+phala profiles delete --help
+```

--- a/phala-cloud/phala-cloud-cli/profiles/rename.mdx
+++ b/phala-cloud/phala-cloud-cli/profiles/rename.mdx
@@ -1,0 +1,44 @@
+---
+title: "profiles rename"
+description: "Rename an auth profile"
+---
+
+## Command: `phala profiles rename`
+
+### Syntax
+
+```
+phala profiles rename <old-name> <new-name>
+```
+
+### Description
+
+Rename an auth profile
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<old-name>` | Current profile name |
+| `<new-name>` | New profile name |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Display help:
+
+```bash
+phala profiles rename --help
+```

--- a/phala-cloud/phala-cloud-cli/profiles/use.mdx
+++ b/phala-cloud/phala-cloud-cli/profiles/use.mdx
@@ -1,0 +1,43 @@
+---
+title: "profiles use"
+description: "Switch to an auth profile"
+---
+
+## Command: `phala profiles use`
+
+### Syntax
+
+```
+phala profiles use [options] <profile-name>
+```
+
+### Description
+
+Switch to an auth profile
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<profile-name>` | Profile name |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `-i, --interactive` | Select profile interactively |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Display help:
+
+```bash
+phala profiles use --help
+```

--- a/phala-cloud/phala-cloud-cli/ps.mdx
+++ b/phala-cloud/phala-cloud-cli/ps.mdx
@@ -3,25 +3,25 @@ title: "ps"
 description: "List containers of a CVM"
 ---
 
-## Command: `phala ps`
+### Command: `phala ps`
 
-### Syntax
+#### Syntax
 
 ```
 phala ps [options] [<cvm_id>]
 ```
 
-### Description
+#### Description
 
 List containers of a CVM
 
-### Arguments
+#### Arguments
 
 | Argument | Description |
 | -------- | ----------- |
 | `<cvm_id>?` | CVM identifier (UUID, app_id, instance_id, or name) |
 
-### Global Options
+#### Global Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -34,7 +34,7 @@ List containers of a CVM
 | `--profile PROFILE` | Temporarily use a different auth profile for this command |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
-### Examples
+#### Examples
 
 * List containers interactively
 

--- a/phala-cloud/phala-cloud-cli/runtime-config.mdx
+++ b/phala-cloud/phala-cloud-cli/runtime-config.mdx
@@ -3,25 +3,25 @@ title: "runtime-config"
 description: "Show the runtime configuration of a CVM"
 ---
 
-## Command: `phala runtime-config`
+### Command: `phala runtime-config`
 
-### Syntax
+#### Syntax
 
 ```
 phala runtime-config [options] [<cvm_id>]
 ```
 
-### Description
+#### Description
 
 Show the runtime configuration of a CVM
 
-### Arguments
+#### Arguments
 
 | Argument | Description |
 | -------- | ----------- |
 | `<cvm_id>?` | CVM identifier (UUID, app_id, instance_id, or name) |
 
-### Global Options
+#### Global Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -34,7 +34,7 @@ Show the runtime configuration of a CVM
 | `--profile PROFILE` | Temporarily use a different auth profile for this command |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
-### Examples
+#### Examples
 
 * Show runtime config by app_id
 

--- a/phala-cloud/phala-cloud-cli/self.mdx
+++ b/phala-cloud/phala-cloud-cli/self.mdx
@@ -1,25 +1,26 @@
 ---
 title: "self"
 description: "CLI self-management"
+hidden: true
 ---
 
 <Note>
 This command is marked as unstable and may change in future releases.
 </Note>
 
-## Command: `phala self`
+### Command: `phala self`
 
-### Syntax
+#### Syntax
 
 ```
 phala self <command> [options]
 ```
 
-### Description
+#### Description
 
 CLI self-management
 
-### Global Options
+#### Global Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -32,16 +33,16 @@ CLI self-management
 | `--profile PROFILE` | Temporarily use a different auth profile for this command |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
-### Subcommands
-
-| Command | Description |
-| ------- | ----------- |
-| `update` | Update the Phala CLI |
-
-### Examples
+#### Examples
 
 * Display help:
 
 ```bash
 phala self --help
 ```
+### Subcommands
+
+| Command | Description |
+| ------- | ----------- |
+| `update` | Update the Phala CLI |
+

--- a/phala-cloud/phala-cloud-cli/self/update.mdx
+++ b/phala-cloud/phala-cloud-cli/self/update.mdx
@@ -1,0 +1,63 @@
+---
+title: "self update"
+description: "Update the Phala CLI"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala self update`
+
+### Syntax
+
+```
+phala self update [options]
+```
+
+### Description
+
+Update the Phala CLI
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-y, --yes` | Skip confirmation prompt |
+| `--dry-run` | Print update command without executing |
+| `--package-manager NAME, --pm NAME` | Override package manager (npm\|pnpm\|yarn\|bun) |
+| `--channel TAG` | Release channel/dist-tag (e.g. latest, beta, next) |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Update CLI
+
+```bash
+phala self update
+```
+
+* Dry run
+
+```bash
+phala self update --dry-run
+```
+
+* Beta channel
+
+```bash
+phala self update --channel beta
+```
+

--- a/phala-cloud/phala-cloud-cli/simulator.mdx
+++ b/phala-cloud/phala-cloud-cli/simulator.mdx
@@ -1,25 +1,26 @@
 ---
 title: "simulator"
 description: "TEE simulator commands"
+hidden: true
 ---
 
 <Note>
 This command is marked as unstable and may change in future releases.
 </Note>
 
-## Command: `phala simulator`
+### Command: `phala simulator`
 
-### Syntax
+#### Syntax
 
 ```
 phala simulator <command> [options]
 ```
 
-### Description
+#### Description
 
 TEE simulator commands
 
-### Global Options
+#### Global Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -32,6 +33,13 @@ TEE simulator commands
 | `--profile PROFILE` | Temporarily use a different auth profile for this command |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
+#### Examples
+
+* Display help:
+
+```bash
+phala simulator --help
+```
 ### Subcommands
 
 | Command | Description |
@@ -39,10 +47,3 @@ TEE simulator commands
 | `start` | Start the TEE simulator |
 | `stop` | Stop the TEE simulator |
 
-### Examples
-
-* Display help:
-
-```bash
-phala simulator --help
-```

--- a/phala-cloud/phala-cloud-cli/simulator/start.mdx
+++ b/phala-cloud/phala-cloud-cli/simulator/start.mdx
@@ -1,0 +1,48 @@
+---
+title: "simulator start"
+description: "Start the TEE simulator"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala simulator start`
+
+### Syntax
+
+```
+phala simulator start [options]
+```
+
+### Description
+
+Start the TEE simulator
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-p, --port <value>` | Simulator port (default: 8090) |
+| `-v, --verbose` | Enable verbose output |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `--version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Display help:
+
+```bash
+phala simulator start --help
+```

--- a/phala-cloud/phala-cloud-cli/simulator/stop.mdx
+++ b/phala-cloud/phala-cloud-cli/simulator/stop.mdx
@@ -1,0 +1,41 @@
+---
+title: "simulator stop"
+description: "Stop the TEE simulator"
+---
+
+<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+## Command: `phala simulator stop`
+
+### Syntax
+
+```
+phala simulator stop
+```
+
+### Description
+
+Stop the TEE simulator
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Display help:
+
+```bash
+phala simulator stop --help
+```

--- a/phala-cloud/phala-cloud-cli/ssh-keys.mdx
+++ b/phala-cloud/phala-cloud-cli/ssh-keys.mdx
@@ -1,21 +1,22 @@
 ---
 title: "ssh-keys"
 description: "Manage SSH keys"
+hidden: true
 ---
 
-## Command: `phala ssh-keys`
+### Command: `phala ssh-keys`
 
-### Syntax
+#### Syntax
 
 ```
 phala ssh-keys <command> [options]
 ```
 
-### Description
+#### Description
 
 Manage SSH keys
 
-### Global Options
+#### Global Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -28,6 +29,13 @@ Manage SSH keys
 | `--profile PROFILE` | Temporarily use a different auth profile for this command |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
+#### Examples
+
+* Display help:
+
+```bash
+phala ssh-keys --help
+```
 ### Subcommands
 
 | Command | Description |
@@ -37,10 +45,3 @@ Manage SSH keys
 | `remove` | Remove an SSH key from your account |
 | `import-github` | Import SSH keys from a GitHub user's public profile |
 
-### Examples
-
-* Display help:
-
-```bash
-phala ssh-keys --help
-```

--- a/phala-cloud/phala-cloud-cli/ssh-keys/add.mdx
+++ b/phala-cloud/phala-cloud-cli/ssh-keys/add.mdx
@@ -1,0 +1,51 @@
+---
+title: "ssh-keys add"
+description: "Add a local SSH public key to your account"
+---
+
+## Command: `phala ssh-keys add`
+
+### Syntax
+
+```
+phala ssh-keys add [options]
+```
+
+### Description
+
+Add a local SSH public key to your account
+
+### Options
+
+| Option | Description |
+| ------ | ----------- |
+| `--name <value>` | Name for the SSH key (default: key file name) |
+| `--key-file <value>` | Path to SSH public key file (default: ~/.ssh/id_ed25519.pub or ~/.ssh/id_rsa.pub) |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Add default SSH key
+
+```bash
+phala ssh-keys add
+```
+
+* Add a specific key with a name
+
+```bash
+phala ssh-keys add --name my-laptop --key-file ~/.ssh/id_ed25519.pub
+```
+

--- a/phala-cloud/phala-cloud-cli/ssh-keys/import-github.mdx
+++ b/phala-cloud/phala-cloud-cli/ssh-keys/import-github.mdx
@@ -1,0 +1,44 @@
+---
+title: "ssh-keys import-github"
+description: "Import SSH keys from a GitHub user's public profile"
+---
+
+## Command: `phala ssh-keys import-github`
+
+### Syntax
+
+```
+phala ssh-keys import-github <github_username>
+```
+
+### Description
+
+Import SSH keys from a GitHub user's public profile
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<github_username>` | GitHub username to import SSH keys from |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Import SSH keys from a GitHub profile
+
+```bash
+phala ssh-keys import-github octocat
+```
+

--- a/phala-cloud/phala-cloud-cli/ssh-keys/list.mdx
+++ b/phala-cloud/phala-cloud-cli/ssh-keys/list.mdx
@@ -1,0 +1,38 @@
+---
+title: "ssh-keys list"
+description: "List SSH keys for the current user"
+---
+
+## Command: `phala ssh-keys list`
+
+### Syntax
+
+```
+phala ssh-keys list
+```
+
+### Description
+
+List SSH keys for the current user
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `--interactive` | Enable interactive mode for commands that support it |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* List all SSH keys
+
+```bash
+phala ssh-keys list
+```
+

--- a/phala-cloud/phala-cloud-cli/ssh-keys/remove.mdx
+++ b/phala-cloud/phala-cloud-cli/ssh-keys/remove.mdx
@@ -1,0 +1,50 @@
+---
+title: "ssh-keys remove"
+description: "Remove an SSH key from your account"
+---
+
+## Command: `phala ssh-keys remove`
+
+### Syntax
+
+```
+phala ssh-keys remove [options] [<key_id>]
+```
+
+### Description
+
+Remove an SSH key from your account
+
+### Arguments
+
+| Argument | Description |
+| -------- | ----------- |
+| `<key_id>?` | SSH key ID to remove (from `phala ssh-keys list`) |
+
+### Global Options
+
+| Option | Description |
+| ------ | ----------- |
+| `-h, --help` | Show help information for the current command |
+| `-v, --version` | Show CLI version |
+| `--api-token TOKEN, --api-key TOKEN` | API token for authenticating with Phala Cloud |
+| `-j, --json, --no-json` | Output in JSON format |
+| `-i, --interactive` | Enable interactive mode |
+| `--cvm-id <value>` | CVM identifier (UUID, app_id, instance_id, or name) |
+| `--profile PROFILE` | Temporarily use a different auth profile for this command |
+| `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
+
+### Examples
+
+* Remove an SSH key by ID
+
+```bash
+phala ssh-keys remove sshkey_xxx
+```
+
+* Interactive selection
+
+```bash
+phala ssh-keys rm -i
+```
+

--- a/phala-cloud/phala-cloud-cli/ssh.mdx
+++ b/phala-cloud/phala-cloud-cli/ssh.mdx
@@ -7,25 +7,25 @@ description: "Connect to a CVM via SSH"
 This command is marked as unstable and may change in future releases.
 </Note>
 
-## Command: `phala ssh`
+### Command: `phala ssh`
 
-### Syntax
+#### Syntax
 
 ```
 phala ssh [options] [<cvm_id>] [--] [...]
 ```
 
-### Description
+#### Description
 
 Connect to a CVM via SSH
 
-### Arguments
+#### Arguments
 
 | Argument | Description |
 | -------- | ----------- |
 | `<cvm_id>?` | CVM identifier (UUID, app_id, instance_id, or name) |
 
-### Options
+#### Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -35,7 +35,7 @@ Connect to a CVM via SSH
 | `-v, --verbose` | Show verbose connection details |
 | `--dry-run` | Print SSH command without executing |
 
-### Global Options
+#### Global Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -48,11 +48,11 @@ Connect to a CVM via SSH
 | `--profile PROFILE` | Temporarily use a different auth profile for this command |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
-### Pass-through Arguments
+#### Pass-through Arguments
 
 All arguments after -- are passed directly to ssh. Common options: -i (identity file), -L (local forward), -R (remote forward), -D (SOCKS proxy), -N (no command), -v (ssh verbose). Any trailing arguments are executed as remote command. Note: -o ProxyCommand is blocked.
 
-### Examples
+#### Examples
 
 * Connect from phala.toml
 

--- a/phala-cloud/phala-cloud-cli/status.mdx
+++ b/phala-cloud/phala-cloud-cli/status.mdx
@@ -3,25 +3,25 @@ title: "status"
 description: "Check authentication status"
 ---
 
-## Command: `phala status`
+### Command: `phala status`
 
-### Syntax
+#### Syntax
 
 ```
 phala status [options]
 ```
 
-### Description
+#### Description
 
 Check authentication status
 
-### Options
+#### Options
 
 | Option | Description |
 | ------ | ----------- |
 | `-d, --debug` | Enable debug output |
 
-### Global Options
+#### Global Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -34,7 +34,7 @@ Check authentication status
 | `--profile PROFILE` | Temporarily use a different auth profile for this command |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
-### Examples
+#### Examples
 
 * Show login status
 

--- a/phala-cloud/phala-cloud-cli/switch.mdx
+++ b/phala-cloud/phala-cloud-cli/switch.mdx
@@ -7,25 +7,25 @@ description: "Switch auth profiles"
 This command is marked as unstable and may change in future releases.
 </Note>
 
-## Command: `phala switch`
+### Command: `phala switch`
 
-### Syntax
+#### Syntax
 
 ```
 phala switch [options] <profile-name>
 ```
 
-### Description
+#### Description
 
 Switch auth profiles
 
-### Arguments
+#### Arguments
 
 | Argument | Description |
 | -------- | ----------- |
 | `<profile-name>` | Profile name |
 
-### Global Options
+#### Global Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -38,7 +38,7 @@ Switch auth profiles
 | `--profile PROFILE` | Temporarily use a different auth profile for this command |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
-### Examples
+#### Examples
 
 * Display help:
 

--- a/phala-cloud/phala-cloud-cli/whoami.mdx
+++ b/phala-cloud/phala-cloud-cli/whoami.mdx
@@ -3,19 +3,19 @@ title: "whoami"
 description: "Print the current user"
 ---
 
-## Command: `phala whoami`
+### Command: `phala whoami`
 
-### Syntax
+#### Syntax
 
 ```
 phala whoami [options]
 ```
 
-### Description
+#### Description
 
 Print the current user
 
-### Global Options
+#### Global Options
 
 | Option | Description |
 | ------ | ----------- |
@@ -28,7 +28,7 @@ Print the current user
 | `--profile PROFILE` | Temporarily use a different auth profile for this command |
 | `--api-version <value>` | API version to use (e.g. 2025-10-28, 2026-01-21) |
 
-### Examples
+#### Examples
 
 * Show current user
 

--- a/phala-cloud/references/cloud-js-sdk/changelog.mdx
+++ b/phala-cloud/references/cloud-js-sdk/changelog.mdx
@@ -3,6 +3,12 @@ title: Changelog
 description: Release history for the @phala/cloud JavaScript SDK
 ---
 
+## [0.2.9](https://github.com/Phala-Network/phala-cloud/compare/js-v0.2.8...js-v0.2.9) (2026-04-17)
+
+### feat
+
+* **sdk,cli:** add POST /apps/{app_id}/instances support ([80498ab](https://github.com/Phala-Network/phala-cloud/commit/80498ab02f56610a21cbbc807b92d878304a1eb2))
+
 ## [0.2.7](https://github.com/Phala-Network/phala-cloud/compare/js-v0.2.6...js-v0.2.7) (2026-04-10)
 
 ### feat

--- a/scripts/generate-cli-docs.js
+++ b/scripts/generate-cli-docs.js
@@ -24,7 +24,7 @@ const SKIP_COMMANDS = new Set(["help", "completion"]);
 
 // Files to preserve (manually edited, not auto-generated)
 // These files won't be overwritten but will still be included in docs.json
-const PRESERVE_FILES = new Set(["overview"]);
+const PRESERVE_FILES = new Set(["overview", "link"]);
 
 // Commands that are deprecated but should redirect to new commands
 const DEPRECATED_REDIRECTS = {
@@ -308,66 +308,37 @@ function parseHelpOutput(output, commandPath) {
   return command;
 }
 
+function h(level) {
+  return "#".repeat(level);
+}
+
 /**
- * Generate MDX content for a command
+ * Render the body of a command (without frontmatter) at a given heading level.
  */
-function generateMdx(command, commandPath) {
+function renderCommandBody(command, commandPath, level) {
   const fullCommand = ["phala", ...commandPath.slice(1)].join(" ");
-  let title =
-    commandPath.length > 1
-      ? commandPath[commandPath.length - 1]
-      : "Overview";
-
-  // Add deprecation marker to title
-  if (command.deprecated) {
-    title += " (Deprecated)";
-  }
-
-  let mdx = `---
-title: "${title}"
-description: "${escapeForYaml(command.description || `Reference for the ${fullCommand} command`)}"
----
-
-`;
-
-  // Add deprecation notice
-  if (command.deprecated) {
-    mdx += `<Warning>
-This command is deprecated. ${DEPRECATED_REDIRECTS[command.name] || "See the newer alternatives."}
-</Warning>
-
-`;
-  }
-
-  // Add unstable notice
-  if (command.unstable) {
-    mdx += `<Note>
-This command is marked as unstable and may change in future releases.
-</Note>
-
-`;
-  }
+  let mdx = "";
 
   // Command header
   if (commandPath.length > 1) {
-    mdx += `## Command: \`${fullCommand}\`\n\n`;
+    mdx += `${h(level)} Command: \`${fullCommand}\`\n\n`;
   } else {
-    mdx += `## Base Command: \`phala\`\n\n`;
+    mdx += `${h(level)} Base Command: \`phala\`\n\n`;
   }
 
   // Syntax
-  mdx += `### Syntax\n\n`;
+  mdx += `${h(level + 1)} Syntax\n\n`;
   mdx += "```\n";
   mdx += command.usage + "\n";
   mdx += "```\n\n";
 
   // Description
-  mdx += `### Description\n\n`;
+  mdx += `${h(level + 1)} Description\n\n`;
   mdx += `${command.description}\n\n`;
 
   // Arguments
   if (command.arguments.length > 0) {
-    mdx += `### Arguments\n\n`;
+    mdx += `${h(level + 1)} Arguments\n\n`;
     mdx += `| Argument | Description |\n`;
     mdx += `| -------- | ----------- |\n`;
     for (const arg of command.arguments) {
@@ -392,7 +363,7 @@ This command is marked as unstable and may change in future releases.
       for (const groupName of groupOrder) {
         const groupOpts = command.optionGroups[groupName];
         if (groupOpts && groupOpts.length > 0) {
-          mdx += `### ${groupName}\n\n`;
+          mdx += `${h(level + 1)} ${groupName}\n\n`;
           mdx += `| Option | Description |\n`;
           mdx += `| ------ | ----------- |\n`;
           for (const opt of groupOpts) {
@@ -405,7 +376,7 @@ This command is marked as unstable and may change in future releases.
       // Only global options — just render as "Global Options"
       const globalOpts = command.optionGroups["Global Options"];
       if (globalOpts && globalOpts.length > 0) {
-        mdx += `### Global Options\n\n`;
+        mdx += `${h(level + 1)} Global Options\n\n`;
         mdx += `| Option | Description |\n`;
         mdx += `| ------ | ----------- |\n`;
         for (const opt of globalOpts) {
@@ -416,37 +387,9 @@ This command is marked as unstable and may change in future releases.
     }
   }
 
-  // Subcommands tables (separate active from deprecated)
-  if (command.subcommands.length > 0) {
-    const activeSubcommands = command.subcommands.filter(sub => !sub.deprecated);
-    const deprecatedSubcommands = command.subcommands.filter(sub => sub.deprecated);
-
-    // Active subcommands
-    if (activeSubcommands.length > 0) {
-      mdx += `### Subcommands\n\n`;
-      mdx += `| Command | Description |\n`;
-      mdx += `| ------- | ----------- |\n`;
-      for (const sub of activeSubcommands) {
-        mdx += `| \`${sub.name}\` | ${escapeForTable(sub.description)} |\n`;
-      }
-      mdx += "\n";
-    }
-
-    // Deprecated subcommands
-    if (deprecatedSubcommands.length > 0) {
-      mdx += `### Deprecated Subcommands\n\n`;
-      mdx += `| Command | Description |\n`;
-      mdx += `| ------- | ----------- |\n`;
-      for (const sub of deprecatedSubcommands) {
-        mdx += `| \`${sub.name}\` | ${escapeForTable(sub.description)} |\n`;
-      }
-      mdx += "\n";
-    }
-  }
-
   // Pass-through section
   if (command.passThrough) {
-    mdx += `### Pass-through Arguments\n\n`;
+    mdx += `${h(level + 1)} Pass-through Arguments\n\n`;
     mdx += command.passThrough
       .split("\n")
       .map((line) => line.trim())
@@ -457,7 +400,7 @@ This command is marked as unstable and may change in future releases.
 
   // Examples
   if (command.examples.length > 0) {
-    mdx += `### Examples\n\n`;
+    mdx += `${h(level + 1)} Examples\n\n`;
     for (const example of command.examples) {
       const lines = example.split("\n");
       for (const line of lines) {
@@ -473,11 +416,92 @@ This command is marked as unstable and may change in future releases.
     }
   } else {
     // Default examples
-    mdx += `### Examples\n\n`;
+    mdx += `${h(level + 1)} Examples\n\n`;
     mdx += `* Display help:\n\n`;
     mdx += "```bash\n";
     mdx += `${fullCommand} --help\n`;
     mdx += "```\n";
+  }
+
+  return mdx;
+}
+
+/**
+ * Generate MDX content for a command
+ */
+function generateMdx(command, commandPath, isStandalone = false) {
+  let title;
+  if (commandPath.length > 2) {
+    // Subcommand — use "parent sub" form so sidebar matches CLI invocation
+    title = commandPath.slice(1).join(" ");
+  } else if (commandPath.length > 1) {
+    // Parent/top-level command
+    title = commandPath[commandPath.length - 1];
+  } else {
+    title = "Overview";
+  }
+
+  // Add deprecation marker to title
+  if (command.deprecated) {
+    title += " (Deprecated)";
+  }
+
+  const hasSubcommands = command.subcommands && command.subcommands.length > 0;
+  const hiddenAttr = !isStandalone && hasSubcommands ? "\nhidden: true" : "";
+
+  let mdx = `---
+title: "${escapeForYaml(title)}"
+description: "${escapeForYaml(command.description || `Reference for the ${["phala", ...commandPath.slice(1)].join(" ")} command`)}"${hiddenAttr}
+---
+
+`;
+
+  // Add deprecation notice
+  if (command.deprecated) {
+    mdx += `<Warning>
+This command is deprecated. ${DEPRECATED_REDIRECTS[command.name] || "See the newer alternatives."}
+</Warning>
+
+`;
+  }
+
+  // Add unstable notice
+  if (command.unstable) {
+    mdx += `<Note>
+This command is marked as unstable and may change in future releases.
+</Note>
+
+`;
+  }
+
+  // Heading level: standalone pages use ##, parent pages use ###
+  const level = isStandalone ? 2 : 3;
+  mdx += renderCommandBody(command, commandPath, level);
+
+  // Subcommands summary table — only on parent pages
+  if (!isStandalone && command.subcommands.length > 0) {
+    const activeSubcommands = command.subcommands.filter(sub => !sub.deprecated);
+    const deprecatedSubcommands = command.subcommands.filter(sub => sub.deprecated);
+
+    if (activeSubcommands.length > 0) {
+      mdx += `### Subcommands\n\n`;
+      mdx += `| Command | Description |\n`;
+      mdx += `| ------- | ----------- |\n`;
+      for (const sub of activeSubcommands) {
+        mdx += `| \`${sub.name}\` | ${escapeForTable(sub.description)} |\n`;
+      }
+      mdx += "\n";
+    }
+
+    if (deprecatedSubcommands.length > 0) {
+      mdx += `### Deprecated Subcommands\n\n`;
+      mdx += `| Command | Description |\n`;
+      mdx += `| ------- | ----------- |\n`;
+      for (const sub of deprecatedSubcommands) {
+        mdx += `| \`${sub.name}\` | ${escapeForTable(sub.description)} |\n`;
+      }
+      mdx += "\n";
+    }
   }
 
   // Replace placeholder domains with realistic Phala examples
@@ -535,6 +559,15 @@ function getAllCommands() {
     // Get subcommands for this command (for reference in the same page)
     if (cmd.subcommands.length > 0) {
       console.log(`    Found ${cmd.subcommands.length} subcommands`);
+      cmd.subcommandDetails = [];
+      for (const nestedSub of cmd.subcommands) {
+        if (SKIP_COMMANDS.has(nestedSub.name)) continue;
+        const nestedOutput = runCommand([subCmd.name, nestedSub.name]);
+        const nestedCmd = parseHelpOutput(nestedOutput, ["phala", subCmd.name, nestedSub.name]);
+        if (nestedSub.deprecated) nestedCmd.deprecated = true;
+        if (nestedSub.unstable) nestedCmd.unstable = true;
+        cmd.subcommandDetails.push(nestedCmd);
+      }
     }
   }
 
@@ -542,16 +575,18 @@ function getAllCommands() {
 }
 
 /**
- * Generate MDX files for all commands
+ * Generate MDX files for all commands and their subcommands
  */
 function generateMdxFiles(commands) {
   const generatedFiles = [];
+  const subcommandGroups = [];
 
   // Ensure output directory exists
   if (!fs.existsSync(OUTPUT_DIR)) {
     fs.mkdirSync(OUTPUT_DIR, { recursive: true });
   }
 
+  // Generate parent command pages
   for (const [name, command] of commands) {
     const filename = `${name}.mdx`;
     const filepath = path.join(OUTPUT_DIR, filename);
@@ -570,46 +605,109 @@ function generateMdxFiles(commands) {
     generatedFiles.push(name);
   }
 
-  return generatedFiles;
+  // Generate standalone subcommand pages
+  for (const [name, command] of commands) {
+    if (command.subcommandDetails && command.subcommandDetails.length > 0) {
+      const subDir = path.join(OUTPUT_DIR, name);
+      if (!fs.existsSync(subDir)) {
+        fs.mkdirSync(subDir, { recursive: true });
+      }
+
+      const subPages = [];
+      for (const sub of command.subcommandDetails) {
+        if (SKIP_COMMANDS.has(sub.name)) continue;
+        const subFile = path.join(subDir, `${sub.name}.mdx`);
+        const subMdx = generateMdx(sub, ["phala", name, sub.name], true);
+        fs.writeFileSync(subFile, subMdx);
+        console.log(`Generated: ${subFile}`);
+        subPages.push(sub.name);
+      }
+
+      if (subPages.length > 0) {
+        subcommandGroups.push({ parent: name, pages: subPages });
+      }
+    }
+  }
+
+  return { generatedFiles, subcommandGroups };
 }
 
 /**
- * Update docs.json with new CLI pages
+ * Update docs.json with new CLI pages and subcommand groups
  */
-function updateDocsJson(commandNames) {
+function updateDocsJson({ generatedFiles, subcommandGroups }) {
   const docsJson = JSON.parse(fs.readFileSync(DOCS_JSON_PATH, "utf-8"));
 
-  // Define the order of commands
-  const commandOrder = [
-    "overview",
-    "login",
-    "logout",
-    "status",
-    "deploy",
-    "cvms",
-    "ssh",
-    "cp",
-    "docker",
-    "simulator",
-    "nodes",
-    "config",
-    "auth", // deprecated, at the end
-  ];
+  // Build a set of parent commands that have subcommands
+  const parentsWithSubcommands = new Set(subcommandGroups.map((g) => g.parent));
 
-  // Sort command names by the defined order
-  const sortedNames = commandNames.sort((a, b) => {
-    const aIndex = commandOrder.indexOf(a);
-    const bIndex = commandOrder.indexOf(b);
-    if (aIndex === -1 && bIndex === -1) return a.localeCompare(b);
-    if (aIndex === -1) return 1;
-    if (bIndex === -1) return -1;
-    return aIndex - bIndex;
-  });
+  // Build a map of parent path -> nested group for subcommands.
+  // Entries are plain strings — the sidebar label comes from each MDX's
+  // frontmatter `title`, which the generator sets to "parent sub".
+  const subcommandMap = new Map();
+  for (const { parent, pages } of subcommandGroups) {
+    const groupPages = [`/phala-cloud/phala-cloud-cli/${parent}`];
+    for (const sub of pages) {
+      groupPages.push(`/phala-cloud/phala-cloud-cli/${parent}/${sub}`);
+    }
+    subcommandMap.set(parent, {
+      group: parent,
+      pages: groupPages,
+    });
+  }
 
-  // Build the new pages array
-  const cliPages = sortedNames.map(
-    (name) => `/phala-cloud/phala-cloud-cli/${name}`
-  );
+  // Wrap a string path into a subcommand group if applicable.
+  // For existing parent commands (like cvms, profiles), this turns the
+  // flat string into the nested group. For new commands, same thing.
+  function wrapIfNeeded(nameOrPath) {
+    const name = typeof nameOrPath === "string"
+      ? nameOrPath.replace("/phala-cloud/phala-cloud-cli/", "")
+      : nameOrPath;
+    if (subcommandMap.has(name)) {
+      return subcommandMap.get(name);
+    }
+    return nameOrPath;
+  }
+
+  // Recursively process a pages array. Two jobs:
+  //  - Replace a parent command's flat path with its subcommand group (only
+  //    at the outermost level where the parent appears as a sibling of other
+  //    commands — not inside its own already-wrapped group).
+  //  - Recurse into existing groups to normalize legacy `{page, title}`
+  //    objects back to plain strings (Mintlify `pages` entries must be a
+  //    string or a nested `{group, pages}` — no other shapes are valid; the
+  //    sidebar label comes from each MDX's frontmatter `title`).
+  //
+  // `insideGroup` is set while recursing into a group with that name; inside
+  // it we must NOT re-wrap `/phala-cloud/phala-cloud-cli/<insideGroup>` into
+  // another nested group, which would compound on each run.
+  function processPages(pages, insideGroup = null) {
+    if (!Array.isArray(pages)) return pages;
+    const result = [];
+    for (const page of pages) {
+      if (typeof page === "string") {
+        const name = page.replace("/phala-cloud/phala-cloud-cli/", "");
+        if (name !== insideGroup && subcommandMap.has(name)) {
+          result.push(subcommandMap.get(name));
+        } else {
+          result.push(page);
+        }
+      } else if (typeof page === "object" && page !== null && Array.isArray(page.pages)) {
+        // If this group corresponds to a freshly-built subcommand group,
+        // replace it outright so we emit a clean, flat list of strings.
+        if (page.group && subcommandMap.has(page.group)) {
+          result.push(subcommandMap.get(page.group));
+        } else {
+          result.push({ ...page, pages: processPages(page.pages, page.group || insideGroup) });
+        }
+      } else if (typeof page === "object" && page !== null && typeof page.page === "string") {
+        result.push(page.page);
+      } else {
+        result.push(page);
+      }
+    }
+    return result;
+  }
 
   // Find and update the CLI Reference group in docs.json
   function findAndUpdateCliGroup(obj) {
@@ -621,7 +719,84 @@ function updateDocsJson(commandNames) {
       }
     } else if (typeof obj === "object" && obj !== null) {
       if (obj.group === "Phala Cloud CLI") {
-        obj.pages = cliPages;
+        const pages = obj.pages;
+        const isGrouped = pages.some((p) => typeof p === "object" && p.group);
+
+        if (isGrouped) {
+          // Collect existing leaf paths (strings and {page} objects)
+          const existingPaths = new Set();
+          const groupMap = {};
+          function collectPaths(items) {
+            for (const p of items) {
+              if (typeof p === "string") {
+                existingPaths.add(p);
+              } else if (p.page) {
+                existingPaths.add(p.page);
+              } else if (p.group && Array.isArray(p.pages)) {
+                groupMap[p.group] = p;
+                collectPaths(p.pages);
+              }
+            }
+          }
+          collectPaths(pages);
+
+          // Add any new parent commands
+          generatedFiles.forEach((name) => {
+            const pagePath = `/phala-cloud/phala-cloud-cli/${name}`;
+            if (existingPaths.has(pagePath)) return;
+            existingPaths.add(pagePath);
+
+            if (name === "instances") {
+              const manage = groupMap["Manage"];
+              if (manage) {
+                const idx = manage.pages.indexOf("/phala-cloud/phala-cloud-cli/apps");
+                if (idx !== -1) {
+                  manage.pages.splice(idx + 1, 0, pagePath);
+                } else {
+                  manage.pages.push(pagePath);
+                }
+              }
+            } else {
+              const firstGroupIndex = pages.findIndex((p) => typeof p === "object");
+              if (firstGroupIndex !== -1) {
+                pages.splice(firstGroupIndex, 0, pagePath);
+              } else {
+                pages.push(pagePath);
+              }
+            }
+          });
+
+          // Replace string paths with subcommand groups in one pass
+          obj.pages = processPages(pages);
+        } else {
+          // Flat list fallback — reconstruct as flat strings
+          const commandOrder = [
+            "overview",
+            "login",
+            "logout",
+            "status",
+            "deploy",
+            "cvms",
+            "ssh",
+            "cp",
+            "docker",
+            "simulator",
+            "nodes",
+            "config",
+            "auth",
+          ];
+          const sortedNames = generatedFiles.sort((a, b) => {
+            const aIndex = commandOrder.indexOf(a);
+            const bIndex = commandOrder.indexOf(b);
+            if (aIndex === -1 && bIndex === -1) return a.localeCompare(b);
+            if (aIndex === -1) return 1;
+            if (bIndex === -1) return -1;
+            return aIndex - bIndex;
+          });
+          obj.pages = sortedNames.map(
+            (name) => `/phala-cloud/phala-cloud-cli/${name}`
+          );
+        }
         return true;
       }
       for (const key of Object.keys(obj)) {
@@ -653,11 +828,12 @@ function main() {
   console.log(`\nTotal commands found: ${commands.size}\n`);
 
   // Generate MDX files
-  const generatedFiles = generateMdxFiles(commands);
-  console.log(`\nGenerated ${generatedFiles.length} MDX files\n`);
+  const { generatedFiles, subcommandGroups } = generateMdxFiles(commands);
+  const totalFiles = generatedFiles.length + subcommandGroups.reduce((sum, g) => sum + g.pages.length, 0);
+  console.log(`\nGenerated ${totalFiles} MDX files (${generatedFiles.length} parents, ${subcommandGroups.length} subcommand groups)\n`);
 
   // Update docs.json
-  updateDocsJson(generatedFiles);
+  updateDocsJson({ generatedFiles, subcommandGroups });
 
   console.log("\nDone! Run 'npx mintlify dev' to preview the documentation.");
 }


### PR DESCRIPTION
## Summary

- Fix CLI docs generator emitting invalid sidebar entries; subcommand pages now carry their sidebar label in the MDX frontmatter.
- Fix OpenAPI reference placement in `docs.json` so endpoint pages render correctly.
- Refresh `openapi.json` to cover only the public API surface.
- Add CLI v1.1.18 and JS SDK v0.2.9 changelog entries (picked up via CLI docs regeneration).

## Test plan

- [x] Pre-commit hooks pass (including Mintlify `docs.json` validation).
- [x] `mintlify broken-links` reports no new broken links.
- [x] Verified in `mintlify dev` that OpenAPI endpoint pages render with the correct server URL and that CLI subcommand pages show the intended titles.
- [ ] Preview build deploys cleanly.