### PR TITLE
docs: hide restricted Phala models endpoint

### DIFF
--- a/phala-cloud/confidential-ai/confidential-model/api-reference/models.mdx
+++ b/phala-cloud/confidential-ai/confidential-model/api-reference/models.mdx
@@ -7,7 +7,6 @@ description: List available Confidential AI models, modalities, context windows,
 
 ```bash
 GET https://inference.phala.com/v1/models
-GET https://inference.phala.com/v1/models/phala
 ```
 
 Use the live model catalog before hardcoding model IDs. The catalog returns model IDs, context windows, pricing, serving metadata, modalities, supported parameters, and whether a model can be served confidentially.
@@ -17,11 +16,6 @@ Use the live model catalog before hardcoding model IDs. The catalog returns mode
 <CodeGroup>
 ```bash All Models
 curl https://inference.phala.com/v1/models \
-  -H "Authorization: Bearer <API_KEY>"
-```
-
-```bash Phala Models
-curl https://inference.phala.com/v1/models/phala \
   -H "Authorization: Bearer <API_KEY>"
 ```
 
@@ -78,7 +72,7 @@ for model in models.data:
 | `max_output_length` | Maximum output length |
 | `pricing.prompt` | Input token price per token; multiply by 1,000,000 for per-million-token pricing |
 | `pricing.completion` | Output token price per token; multiply by 1,000,000 for per-million-token pricing |
-| `providers` | Serving routes available for the model. Use `/v1/models/phala` when you only want Phala-backed models. |
+| `providers` | Serving routes available for the model. |
 | `input_modalities` | Supported input types, such as `text` or `image` |
 | `output_modalities` | Supported output types, such as `text` or `embeddings` |
 | `supported_parameters` | Request parameters accepted by the model |

--- a/phala-cloud/confidential-ai/confidential-model/confidential-ai-api.mdx
+++ b/phala-cloud/confidential-ai/confidential-model/confidential-ai-api.mdx
@@ -123,13 +123,6 @@ curl https://inference.phala.com/v1/models \
   -H "Authorization: Bearer <API_KEY>"
 ```
 
-To list Phala-backed models only:
-
-```bash
-curl https://inference.phala.com/v1/models/phala \
-  -H "Authorization: Bearer <API_KEY>"
-```
-
 Pricing and availability can change; use the API response for production routing.
 
 ### Phala Models


### PR DESCRIPTION
## Summary
- Remove public documentation for the restricted /v1/models/phala endpoint
- Keep /v1/models as the documented model catalog endpoint
- Remove text that directs users to the Phala-only model endpoint

## Test Plan
- jq empty docs.json
- python3 .scripts/check_links.py
- git diff --check