### PR TITLE
docs: update dstack-ingress custom domain examples

### DIFF
--- a/phala-cloud/confidential-ai/gpu-tee-deployment-guide.mdx
+++ b/phala-cloud/confidential-ai/gpu-tee-deployment-guide.mdx
@@ -148,6 +148,7 @@ const response = await client.chat.completions.create({
 });
 console.log(response.choices[0].message.content);
 ```
+
 </CodeGroup>
 
 You can also check the available models and server health:
@@ -212,25 +213,29 @@ Expose your model API on your own domain by adding dstack-ingress to your Docker
 ```yaml
 services:
   dstack-ingress:
-    image: dstacktee/dstack-ingress:20250924@sha256:40429d78060ef3066b5f93676bf3ba7c2e9ac47d4648440febfdda558aed4b32
+    image: dstacktee/dstack-ingress:2.2@sha256:d05a7b343c37c1cca1bba8dbf7e8f3c6d2118158af2d41c455103796db4f67f0
     ports:
       - "443:443"
     environment:
       - DOMAIN=ai.mycompany.com
-      - TARGET_ENDPOINT=http://vllm:8000
+      - TARGET_ENDPOINT=vllm:8000
       - CLOUDFLARE_API_TOKEN=${CLOUDFLARE_API_TOKEN}
       - GATEWAY_DOMAIN=_.${DSTACK_GATEWAY_DOMAIN}
       - CERTBOT_EMAIL=${CERTBOT_EMAIL}
       - SET_CAA=true
     volumes:
       - /var/run/dstack.sock:/var/run/dstack.sock
+      - /var/run/tappd.sock:/var/run/tappd.sock
       - cert-data:/etc/letsencrypt
+      - evidences:/evidences
 
   vllm:
+    image: vllm/vllm-openai:v0.8.5
     # ... your vLLM config from above
 
 volumes:
   cert-data:
+  evidences:
 ```
 
 See [Set Up a Custom Domain](/phala-cloud/networking/setup-custom-domain) for the full guide including DNS provider configuration and troubleshooting.

--- a/phala-cloud/networking/setup-custom-domain.mdx
+++ b/phala-cloud/networking/setup-custom-domain.mdx
@@ -46,34 +46,44 @@ Update your `docker-compose.yml` to include the dstack-ingress container:
 ```yaml
 services:
   dstack-ingress:
-    image: dstacktee/dstack-ingress:20250924@sha256:40429d78060ef3066b5f93676bf3ba7c2e9ac47d4648440febfdda558aed4b32
+    image: dstacktee/dstack-ingress:2.2@sha256:d05a7b343c37c1cca1bba8dbf7e8f3c6d2118158af2d41c455103796db4f67f0
     ports:
       - "443:443"
     environment:
       - DOMAIN=api.mycompany.com  # Your custom domain
-      - TARGET_ENDPOINT=http://app:80  # Your app's internal endpoint
+      - TARGET_ENDPOINT=app:80  # Your app's internal endpoint
       - CLOUDFLARE_API_TOKEN=${CLOUDFLARE_API_TOKEN}
       - GATEWAY_DOMAIN=_.${DSTACK_GATEWAY_DOMAIN}
       - CERTBOT_EMAIL=${CERTBOT_EMAIL}
       - SET_CAA=true
     volumes:
       - /var/run/dstack.sock:/var/run/dstack.sock
+      - /var/run/tappd.sock:/var/run/tappd.sock
       - cert-data:/etc/letsencrypt
+      - evidences:/evidences
     restart: unless-stopped
 
   app:
     image: your-app:latest  # Your application
+    volumes:
+      - evidences:/evidences:ro
     # No ports exposed here - dstack-ingress handles external access
 
 volumes:
   cert-data:  # Persistent storage for SSL certificates
+  evidences:  # Generated attestation evidence files
 ```
 
 Set `DOMAIN` to your custom domain and `TARGET_ENDPOINT` to your app's internal endpoint. `TARGET_ENDPOINT` tells dstack-ingress where to forward incoming traffic:
 
-- `http://app:80` - Forward to service named "app" on port 80
-- `http://api:3000` - Forward to service named "api" on port 3000
+- `app:80` - Forward to service named "app" on port 80
+- `api:3000` - Forward to service named "api" on port 3000
+- `http://app:80` and `grpc://app:50051` are also accepted, but the protocol prefix is stripped before proxying
 - Use the service name from docker-compose, not localhost
+
+<Note>
+`dstack-ingress` is a HAProxy-based L4/TCP proxy. It terminates TLS and forwards the TCP stream to `TARGET_ENDPOINT`; it does not apply Nginx-style HTTP redirects, header rules, body limits, or buffering settings. Put HTTP-specific behavior in your application or in a separate HTTP proxy behind `TARGET_ENDPOINT` if needed.
+</Note>
 
 ## Step 3: Configure Environment Variables
 
@@ -104,7 +114,7 @@ Deploy your updated docker-compose.yml through the dashboard. The first deployme
 
 1. Configures DNS records
 2. Requests SSL certificate from Let's Encrypt
-3. Sets up the reverse proxy
+3. Starts the HAProxy TCP proxy
 
 ## Step 5: Verify
 
@@ -114,60 +124,54 @@ After deployment, you can:
 2. **Check certificate**: Your browser should show a valid Let's Encrypt certificate
 3. **Verify evidence**: Visit `https://api.mycompany.com/evidences/` to see attestation data
 
-## Multiple Services with Custom Domains
+## Multiple Custom Domains
 
-You can use multiple custom domains in one deployment. Note that you need to explicitly set the listen port for each service.
+You can route multiple custom domains from one ingress container by using `DOMAINS` and `ROUTING_MAP`:
 
 ```yaml
 services:
-  # API with custom domain
-  api-ingress:
-    image: dstacktee/dstack-ingress:20250924@sha256:40429d78060ef3066b5f93676bf3ba7c2e9ac47d4648440febfdda558aed4b32
+  ingress:
+    image: dstacktee/dstack-ingress:2.2@sha256:d05a7b343c37c1cca1bba8dbf7e8f3c6d2118158af2d41c455103796db4f67f0
     ports:
       - "443:443"
     environment:
-      - DOMAIN=api.mycompany.com
-      - TARGET_ENDPOINT=http://api:8080
-      - CLOUDFLARE_API_TOKEN=${CLOUDFLARE_API_TOKEN}
-      - GATEWAY_DOMAIN=_.${DSTACK_GATEWAY_DOMAIN}
-      - CERTBOT_EMAIL=${CERTBOT_EMAIL}
-      - SET_CAA=true
-      - PORT=443 # Explicitly set the listen port
+      DNS_PROVIDER: cloudflare
+      CLOUDFLARE_API_TOKEN: ${CLOUDFLARE_API_TOKEN}
+      CERTBOT_EMAIL: ${CERTBOT_EMAIL}
+      GATEWAY_DOMAIN: _.${DSTACK_GATEWAY_DOMAIN}
+      SET_CAA: true
+      DOMAINS: |
+        app.mycompany.com
+        api.mycompany.com
+      ROUTING_MAP: |
+        app.mycompany.com=frontend:3000
+        api.mycompany.com=api:8080
     volumes:
       - /var/run/dstack.sock:/var/run/dstack.sock
-      - api-cert-data:/etc/letsencrypt
-
-  # Frontend with custom domain  
-  web-ingress:
-    image: dstacktee/dstack-ingress:20250924@sha256:40429d78060ef3066b5f93676bf3ba7c2e9ac47d4648440febfdda558aed4b32
-    ports:
-      - "444:444"  # Different host port
-    environment:
-      - DOMAIN=app.mycompany.com
-      - TARGET_ENDPOINT=http://frontend:3000
-      - CLOUDFLARE_API_TOKEN=${CLOUDFLARE_API_TOKEN}
-      - GATEWAY_DOMAIN=_.${DSTACK_GATEWAY_DOMAIN}
-      - CERTBOT_EMAIL=${CERTBOT_EMAIL}
-      - SET_CAA=true
-      - PORT=444 # Explicitly set the listen port
-    volumes:
-      - /var/run/dstack.sock:/var/run/dstack.sock
-      - web-cert-data:/etc/letsencrypt
+      - /var/run/tappd.sock:/var/run/tappd.sock
+      - cert-data:/etc/letsencrypt
+      - evidences:/evidences
+    restart: unless-stopped
 
   api:
     image: my-api:latest
+    volumes:
+      - evidences:/evidences:ro
   
   frontend:
     image: my-frontend:latest
+    volumes:
+      - evidences:/evidences:ro
 
 volumes:
-  api-cert-data:
-  web-cert-data:
+  cert-data:
+  evidences:
 ```
 
 ## Why We Pin Infrastructure Images
 
 The dstack-ingress image uses a SHA256 hash instead of a tag to ensure:
+
 - **Auditability**: Anyone can verify the exact infrastructure code handling domains
 - **Immutability**: The ingress behavior never changes unexpectedly
 - **Security**: Prevents infrastructure image substitution
@@ -176,6 +180,7 @@ The dstack-ingress image uses a SHA256 hash instead of a tag to ensure:
 ## Security Features
 
 When `SET_CAA=true` is enabled:
+
 - CAA records restrict certificate issuance to the TEE managed Let's Encrypt account
 - Only certificates requested from within your TEE can be issued
 - Certificate transparency logs can be monitored for unauthorized certificates
@@ -184,13 +189,16 @@ When `SET_CAA=true` is enabled:
 **Cloudflare Users**: Cloudflare automatically overrides CAA records at the apex domain (e.g., `example.com`). This prevents domain attestation from working correctly.
 
 **Solution options:**
+
 1. **Use a subdomain** (recommended): Deploy to `app.example.com` instead of `example.com`
 2. **Disable Cloudflare's CAA management**: See [Cloudflare CAA documentation](https://developers.cloudflare.com/ssl/edge-certificates/caa-records/#caa-records-added-by-cloudflare)
 
 **To verify your CAA record is working:**
+
 ```bash
 dig @1.1.1.1 +short CAA your-domain.com
 ```
+
 Should return the Let's Encrypt account URI with `validationmethods=dns-01;accounturi=...`
 </Warning>
 
@@ -200,7 +208,7 @@ Should return the Let's Encrypt account URI with `validationmethods=dns-01;accou
 
 Look for dstack-ingress container logs in the dashboard:
 
-```
+```text
 Successfully received certificate.
 Generated evidences successfully
 Next renewal check in 12 hours

--- a/phala-cloud/networking/setup-grpc-service.mdx
+++ b/phala-cloud/networking/setup-grpc-service.mdx
@@ -14,6 +14,7 @@ This guide shows you how to deploy gRPC services with native HTTP/2 support and 
 ## How gRPC Works Through the Gateway
 
 gRPC services get special HTTP/2 treatment:
+
 1. Add a `g` suffix to your port: `<app-id>-<port>g.<cluster>.phala.network`
 2. Gateway detects the `g` suffix and enables HTTP/2 via ALPN negotiation
 3. gRPC traffic flows over HTTP/2 with automatic TLS termination
@@ -67,6 +68,7 @@ const client = new YourService(
     credentials
 );
 ```
+
 </CodeGroup>
 
 ## gRPC with Custom Domains
@@ -76,27 +78,33 @@ Use dstack-ingress for custom domains:
 ```yaml
 services:
   dstack-ingress:
-    image: dstacktee/dstack-ingress:20250924@sha256:40429d78060ef3066b5f93676bf3ba7c2e9ac47d4648440febfdda558aed4b32
+    image: dstacktee/dstack-ingress:2.2@sha256:d05a7b343c37c1cca1bba8dbf7e8f3c6d2118158af2d41c455103796db4f67f0
     ports:
       - "443:443"
     environment:
       - DOMAIN=api.mycompany.com
-      - TARGET_ENDPOINT=grpc://grpc-server:50051  # Note: grpc:// prefix
+      - TARGET_ENDPOINT=grpc-server:50051
+      - ALPN=h2  # Allow gRPC clients to negotiate HTTP/2
       - CLOUDFLARE_API_TOKEN=${CLOUDFLARE_API_TOKEN}
       - GATEWAY_DOMAIN=_.${DSTACK_GATEWAY_DOMAIN}
       - CERTBOT_EMAIL=${CERTBOT_EMAIL}
     volumes:
       - /var/run/dstack.sock:/var/run/dstack.sock
+      - /var/run/tappd.sock:/var/run/tappd.sock
       - cert-data:/etc/letsencrypt
+      - evidences:/evidences
 
   grpc-server:
     image: your-grpc-service:latest
 
 volumes:
   cert-data:
+  evidences:
 ```
 
 Then connect to: `api.mycompany.com`. Learn more details at [Set up custom domains](/phala-cloud/networking/setup-custom-domain).
+
+`dstack-ingress` terminates TLS and forwards raw TCP to the backend. For gRPC custom domains, set `ALPN=h2` so clients can negotiate HTTP/2 over TLS; your backend should accept cleartext HTTP/2 on `TARGET_ENDPOINT`.
 
 ## Testing with grpcurl
 
@@ -113,11 +121,13 @@ grpcurl -d '{"name": "world"}' \
 ## Key Differences
 
 **gRPC (with `g` suffix):**
+
 - Native HTTP/2 with ALPN negotiation
 - Optimal performance for gRPC protocols
 - Proper streaming support
 
 **Regular HTTP:**
+
 - Standard HTTP/1.1 or HTTP/2
 - Best for REST APIs and web applications
 - No gRPC-specific optimizations

--- a/phala-cloud/networking/specifications.mdx
+++ b/phala-cloud/networking/specifications.mdx
@@ -15,6 +15,7 @@ description: Quick lookup for URL patterns, environment variables, and configura
 | `{app-id}-22.{cluster}.phala.network` | SSH tunnel | `deadbeef111111111111111111111111-22.dstack-prod5.phala.network` |
 
 **Default Port Behaviors:**
+
 - No port specified = routes to port 80 for HTTP or port 443 for TLS passthrough
 - All external connections use port 443 regardless of internal port
 - `{app-id}` is auto-generated on deployment
@@ -35,22 +36,28 @@ You can use these variables in your docker-compose file:
 The variables you can change to config networking features.
 
 ### SSH Access
+
 | Variable | Type | Purpose |
 |----------|------|---------|
 | `DSTACK_ROOT_PASSWORD` | string | Root password (dev images only) |
 | `DSTACK_ROOT_PUBLIC_KEY` | string | SSH public key (dev images only) |
 
 ### Custom Domains
+
 | Variable | Required | Type | Purpose |
 |----------|----------|------|---------|
-| `DOMAIN` | Yes | string | Custom domain name |
-| `TARGET_ENDPOINT` | Yes | string | `http://service:port` or `grpc://service:port` |
+| `DOMAIN` | Conditional | string | Single custom domain name; use `DOMAINS` for multi-domain mode |
+| `DOMAINS` | Conditional | string | Multiple custom domain names, one per line |
+| `TARGET_ENDPOINT` | Conditional | string | Backend address for single-domain mode, such as `app:80`; protocol prefixes like `http://` and `grpc://` are accepted and stripped |
+| `ROUTING_MAP` | Conditional | string | Multi-domain routing entries, one `domain=service:port` entry per line |
 | `GATEWAY_DOMAIN` | Yes | string | `_.${DSTACK_GATEWAY_DOMAIN}` |
 | `CERTBOT_EMAIL` | Yes | string | Let's Encrypt email |
 | `SET_CAA` | No | boolean | Enable CAA records (default: false) |
 | `DNS_PROVIDER` | No | string | `cloudflare|linode|namecheap` (auto-detected) |
+| `ALPN` | No | string | TLS ALPN protocols, such as `h2` for gRPC custom domains |
 
 ### DNS Provider Credentials
+
 | Provider | Variables | Required Permissions |
 |----------|-----------|---------------------|
 | Cloudflare | `CLOUDFLARE_API_TOKEN` | Zone:Read, DNS:Edit |
@@ -71,11 +78,12 @@ The variables you can change to config networking features.
 
 | Component | Image | Hash |
 |-----------|-------|------|
-| Custom domains | `dstacktee/dstack-ingress:20250924` | `sha256:40429d78060ef3066b5f93676bf3ba7c2e9ac47d4648440febfdda558aed4b32` |
+| Custom domains | `dstacktee/dstack-ingress:2.2` | `sha256:d05a7b343c37c1cca1bba8dbf7e8f3c6d2118158af2d41c455103796db4f67f0` |
 
 ## Rate Limits
 
 ### DNS Providers
+
 | Provider | API Limits | Certificate Speed |
 |----------|------------|-------------------|
 | Cloudflare | 1200 req/5min | 1-2 minutes |
@@ -83,9 +91,9 @@ The variables you can change to config networking features.
 | Namecheap | 50 req/hour | 5-15 minutes |
 
 ### Let's Encrypt
+
 | Limit | Rate |
 |-------|------|
 | Certificates per domain | 50/week |
 | Duplicate certificates | 5/week |
 | Failed validations | 5/hour per hostname |
-


### PR DESCRIPTION
## Summary
- update custom domain examples to `dstacktee/dstack-ingress:2.2@sha256:d05a7b343c37c1cca1bba8dbf7e8f3c6d2118158af2d41c455103796db4f67f0`
- align examples with the current HAProxy L4/TCP model, including bare `TARGET_ENDPOINT` values, `tappd.sock`, and `/evidences` volume mounts
- replace the multi-domain example with `DOMAINS` + `ROUTING_MAP` and update gRPC custom domains to set `ALPN=h2`
- sync the remaining custom-domain ingress example in the GPU TEE guide

## Validation
- `npx --yes markdownlint-cli2@0.10.0 --config .markdownlint.yaml phala-cloud/networking/setup-custom-domain.mdx phala-cloud/networking/setup-grpc-service.mdx phala-cloud/networking/specifications.mdx phala-cloud/confidential-ai/gpu-tee-deployment-guide.mdx`
- `git diff --check`
- `python3 .scripts/check_links.py` (after creating ignored `tmp/`; uncovered links: 0)
- parsed updated docker-compose examples with `docker compose -f - config --quiet`
- searched for old `dstack-ingress:20250924` digest references

Note: `.scripts/check-redpill-confidential-ai-sync.sh` could not fetch the private `redpill-ai/redpill-docs-v2` repo locally without credentials, so it reported skipped.