### PR TITLE
docs: mark DSTACK_ROOT_PASSWORD as unusable for SSH since dstack 0.5.6

### DIFF
--- a/phala-cloud/cvm/set-secure-environment-variables.mdx
+++ b/phala-cloud/cvm/set-secure-environment-variables.mdx
@@ -229,11 +229,12 @@ include it in your Docker image.
 
 | Variable | Required | Description |
 | --- | --- | --- |
+| `DSTACK_ROOT_PASSWORD` | No | Linux root password for dstack OS. If not set, a random 32-character password is generated. Starting with dstack 0.5.6, SSH password login is disabled, so this password no longer lets you SSH in. |
 | `DSTACK_ROOT_PUBLIC_KEY` | No | SSH public key added to `/home/root/.ssh/authorized_keys` |
 | `DSTACK_AUTHORIZED_KEYS` | No | SSH authorized keys for `/home/root/.ssh/authorized_keys`. Overwrites `DSTACK_ROOT_PUBLIC_KEY` if both are set. |
 
 <Warning>
-For security, `DSTACK_ROOT_PUBLIC_KEY` and `DSTACK_AUTHORIZED_KEYS` are
+For security, `DSTACK_ROOT_PASSWORD`, `DSTACK_ROOT_PUBLIC_KEY`, and `DSTACK_AUTHORIZED_KEYS` are
 **unset** from the environment immediately after they are applied. They will **not** be visible to
 your Docker Compose services.
 </Warning>

--- a/phala-cloud/cvm/set-secure-environment-variables.mdx
+++ b/phala-cloud/cvm/set-secure-environment-variables.mdx
@@ -229,7 +229,7 @@ include it in your Docker image.
 
 | Variable | Required | Description |
 | --- | --- | --- |
-| `DSTACK_ROOT_PASSWORD` | No | Linux root password for dstack OS. If not set, a random 32-character password is generated. Starting with dstack 0.5.6, SSH password login is disabled, so this password no longer lets you SSH in. |
+| `DSTACK_ROOT_PASSWORD` | No | Linux root password inside the CVM. Since dstack 0.5.6, SSH rejects password logins, so this does not get you an SSH session. If you do not set it, a random 32-character password is generated. |
 | `DSTACK_ROOT_PUBLIC_KEY` | No | SSH public key added to `/home/root/.ssh/authorized_keys` |
 | `DSTACK_AUTHORIZED_KEYS` | No | SSH authorized keys for `/home/root/.ssh/authorized_keys`. Overwrites `DSTACK_ROOT_PUBLIC_KEY` if both are set. |
 

--- a/phala-cloud/cvm/set-secure-environment-variables.mdx
+++ b/phala-cloud/cvm/set-secure-environment-variables.mdx
@@ -229,12 +229,11 @@ include it in your Docker image.
 
 | Variable | Required | Description |
 | --- | --- | --- |
-| `DSTACK_ROOT_PASSWORD` | No | Linux root password for dstack OS. If not set, a random 32-character password is generated. |
 | `DSTACK_ROOT_PUBLIC_KEY` | No | SSH public key added to `/home/root/.ssh/authorized_keys` |
 | `DSTACK_AUTHORIZED_KEYS` | No | SSH authorized keys for `/home/root/.ssh/authorized_keys`. Overwrites `DSTACK_ROOT_PUBLIC_KEY` if both are set. |
 
 <Warning>
-For security, `DSTACK_ROOT_PASSWORD`, `DSTACK_ROOT_PUBLIC_KEY`, and `DSTACK_AUTHORIZED_KEYS` are
+For security, `DSTACK_ROOT_PUBLIC_KEY` and `DSTACK_AUTHORIZED_KEYS` are
 **unset** from the environment immediately after they are applied. They will **not** be visible to
 your Docker Compose services.
 </Warning>

--- a/phala-cloud/networking/enable-ssh-access.mdx
+++ b/phala-cloud/networking/enable-ssh-access.mdx
@@ -20,6 +20,10 @@ Start by adding your SSH keys in **Account Settings > SSH Keys** on the [Phala C
 
 When creating a CVM, the SSH Authorization section lets you add an additional public key specific to that instance. It is added alongside your account keys.
 
+<Warning>
+Starting with dstack 0.5.6, SSH password login is disabled. `DSTACK_ROOT_PASSWORD` still sets the Linux root password for console use, but you cannot SSH in with it. Use a public key instead.
+</Warning>
+
 <Note>
 SSH keys are injected **only at CVM creation time**. Updating your account keys won't affect already-deployed CVMs. To modify credentials on existing CVMs, use **Code Update** to set the `DSTACK_ROOT_PUBLIC_KEY` environment variable.
 </Note>

--- a/phala-cloud/networking/enable-ssh-access.mdx
+++ b/phala-cloud/networking/enable-ssh-access.mdx
@@ -4,10 +4,10 @@ description: Connect to your CVM via SSH for debugging and management
 ---
 
 <Warning>
-SSH access is only available with dev OS images. Select "dstack-dev" when creating your CVM. Production images have SSH disabled for security. Since dstack 0.5.6, only public key login works — password login is disabled.
+SSH works only on dev OS images. Select "dstack-dev" when you create your CVM. Production images have SSH turned off for security. You sign in with an SSH key. Passwords do not work.
 </Warning>
 
-The easiest way to SSH into your CVM is with the Phala CLI. One command connects you through the secure gateway tunnel.
+The Phala CLI connects you through the secure gateway tunnel in one command.
 
 ## Prerequisites
 
@@ -18,15 +18,13 @@ The easiest way to SSH into your CVM is with the Phala CLI. One command connects
 
 Start by adding your SSH keys in **Account Settings > SSH Keys** on the [Phala Cloud dashboard](https://cloud.phala.com/account/settings). You can add keys manually or sync them from GitHub. All saved keys are automatically added to every new CVM you deploy.
 
-When creating a CVM, the SSH Authorization section lets you add an additional public key specific to that instance. It is added alongside your account keys.
+When creating a CVM, the SSH Authorization section lets you add one more public key just for that CVM. It is added alongside your account keys.
 
-<Warning>
-Starting with dstack 0.5.6, SSH password login is disabled. `DSTACK_ROOT_PASSWORD` still sets the Linux root password for console use, but you cannot SSH in with it. Use a public key instead.
-</Warning>
+Your keys are copied into the CVM when it starts for the first time. Adding a key to your account later does not reach a CVM that is already running. To add a key to a running CVM, use **Code Update** and set the `DSTACK_ROOT_PUBLIC_KEY` environment variable.
 
-<Note>
-SSH keys are injected **only at CVM creation time**. Updating your account keys won't affect already-deployed CVMs. To modify credentials on existing CVMs, use **Code Update** to set the `DSTACK_ROOT_PUBLIC_KEY` environment variable.
-</Note>
+### Why can't I sign in with a password?
+
+Since dstack 0.5.6, the SSH server rejects password logins. Only keys work. `DSTACK_ROOT_PASSWORD` still sets the Linux root password inside the CVM, but SSH will turn it down no matter what you set it to. Add a public key instead.
 
 ## Step 2: Connect
 
@@ -109,7 +107,7 @@ Remember to switch to a Production OS image when you're done debugging.
 
 | Issue | Solution |
 |-------|----------|
-| Permission denied | Check Account Settings for saved keys. For existing CVMs, use Code Update to set credentials. |
+| Permission denied | Check that Account Settings has the key you are using. Passwords are rejected. For a running CVM, use Code Update to add a key. |
 | Connection refused | Confirm you deployed with Development OS, not Production |
 | Connection timeout | Run `phala ssh -v` to see detailed connection info |
 

--- a/phala-cloud/networking/enable-ssh-access.mdx
+++ b/phala-cloud/networking/enable-ssh-access.mdx
@@ -18,10 +18,10 @@ The easiest way to SSH into your CVM is with the Phala CLI. One command connects
 
 Start by adding your SSH keys in **Account Settings > SSH Keys** on the [Phala Cloud dashboard](https://cloud.phala.com/account/settings). You can add keys manually or sync them from GitHub. All saved keys are automatically added to every new CVM you deploy.
 
-When creating a CVM, the SSH Authorization section lets you add an additional root password or public key specific to that instance. These are added alongside your account keys.
+When creating a CVM, the SSH Authorization section lets you add an additional public key specific to that instance. It is added alongside your account keys.
 
 <Note>
-SSH keys are injected **only at CVM creation time**. Updating your account keys won't affect already-deployed CVMs. To modify credentials on existing CVMs, use **Code Update** to set the `DSTACK_ROOT_PASSWORD` or `DSTACK_ROOT_PUBLIC_KEY` environment variables.
+SSH keys are injected **only at CVM creation time**. Updating your account keys won't affect already-deployed CVMs. To modify credentials on existing CVMs, use **Code Update** to set the `DSTACK_ROOT_PUBLIC_KEY` environment variable.
 </Note>
 
 ## Step 2: Connect

--- a/phala-cloud/networking/enable-ssh-access.mdx
+++ b/phala-cloud/networking/enable-ssh-access.mdx
@@ -4,7 +4,7 @@ description: Connect to your CVM via SSH for debugging and management
 ---
 
 <Warning>
-SSH access is only available with **dev** OS images. Select "dstack-dev" when creating your CVM. Production images have SSH disabled for security.
+SSH access is only available with dev OS images. Select "dstack-dev" when creating your CVM. Production images have SSH disabled for security. Since dstack 0.5.6, only public key login works — password login is disabled.
 </Warning>
 
 The easiest way to SSH into your CVM is with the Phala CLI. One command connects you through the secure gateway tunnel.

--- a/phala-cloud/networking/specifications.mdx
+++ b/phala-cloud/networking/specifications.mdx
@@ -39,6 +39,7 @@ The variables you can change to config networking features.
 
 | Variable | Type | Purpose |
 |----------|------|---------|
+| `DSTACK_ROOT_PASSWORD` | string | Root password (dev images only). Starting with dstack 0.5.6, SSH password login is disabled, so this password cannot be used to SSH in. |
 | `DSTACK_ROOT_PUBLIC_KEY` | string | SSH public key (dev images only) |
 
 ### Custom Domains

--- a/phala-cloud/networking/specifications.mdx
+++ b/phala-cloud/networking/specifications.mdx
@@ -39,7 +39,6 @@ The variables you can change to config networking features.
 
 | Variable | Type | Purpose |
 |----------|------|---------|
-| `DSTACK_ROOT_PASSWORD` | string | Root password (dev images only) |
 | `DSTACK_ROOT_PUBLIC_KEY` | string | SSH public key (dev images only) |
 
 ### Custom Domains

--- a/phala-cloud/networking/specifications.mdx
+++ b/phala-cloud/networking/specifications.mdx
@@ -39,7 +39,7 @@ The variables you can change to config networking features.
 
 | Variable | Type | Purpose |
 |----------|------|---------|
-| `DSTACK_ROOT_PASSWORD` | string | Root password (dev images only). Not usable for SSH login since dstack 0.5.6 |
+| `DSTACK_ROOT_PASSWORD` | string | Root password inside the CVM (dev images only). SSH rejects it since dstack 0.5.6 |
 | `DSTACK_ROOT_PUBLIC_KEY` | string | SSH public key (dev images only) |
 
 ### Custom Domains

--- a/phala-cloud/networking/specifications.mdx
+++ b/phala-cloud/networking/specifications.mdx
@@ -39,7 +39,7 @@ The variables you can change to config networking features.
 
 | Variable | Type | Purpose |
 |----------|------|---------|
-| `DSTACK_ROOT_PASSWORD` | string | Root password (dev images only). Starting with dstack 0.5.6, SSH password login is disabled, so this password cannot be used to SSH in. |
+| `DSTACK_ROOT_PASSWORD` | string | Root password (dev images only). Not usable for SSH login since dstack 0.5.6 |
 | `DSTACK_ROOT_PUBLIC_KEY` | string | SSH public key (dev images only) |
 
 ### Custom Domains

--- a/phala-cloud/troubleshooting/troubleshooting.mdx
+++ b/phala-cloud/troubleshooting/troubleshooting.mdx
@@ -135,7 +135,7 @@ See the [SSH access guide](/phala-cloud/networking/enable-ssh-access) for detail
 **Common issues:**
 - Not using Development OS image (SSH is disabled on Production OS)
 - Missing `DSTACK_ROOT_PUBLIC_KEY` environment variable
-- Trying to log in with a root password: dstack 0.5.6 and later disable SSH password login, so only public keys work
+- Signing in with a root password. Since dstack 0.5.6, SSH rejects passwords. Use a public key.
 - Using LibreSSL instead of OpenSSL on macOS
 
 ## GPU TEE Issues

--- a/phala-cloud/troubleshooting/troubleshooting.mdx
+++ b/phala-cloud/troubleshooting/troubleshooting.mdx
@@ -134,7 +134,7 @@ See the [SSH access guide](/phala-cloud/networking/enable-ssh-access) for detail
 
 **Common issues:**
 - Not using Development OS image (SSH is disabled on Production OS)
-- Missing `DSTACK_ROOT_PASSWORD` or `DSTACK_ROOT_PUBLIC_KEY` environment variables
+- Missing `DSTACK_ROOT_PUBLIC_KEY` environment variable
 - Using LibreSSL instead of OpenSSL on macOS
 
 ## GPU TEE Issues

--- a/phala-cloud/troubleshooting/troubleshooting.mdx
+++ b/phala-cloud/troubleshooting/troubleshooting.mdx
@@ -135,6 +135,7 @@ See the [SSH access guide](/phala-cloud/networking/enable-ssh-access) for detail
 **Common issues:**
 - Not using Development OS image (SSH is disabled on Production OS)
 - Missing `DSTACK_ROOT_PUBLIC_KEY` environment variable
+- Trying to log in with a root password: dstack 0.5.6 and later disable SSH password login, so only public keys work
 - Using LibreSSL instead of OpenSSL on macOS
 
 ## GPU TEE Issues


### PR DESCRIPTION
## Why

Starting with dstack 0.5.6, SSH password login is disabled. `DSTACK_ROOT_PASSWORD` still exists and still sets the Linux root password, but it no longer gets you an SSH session. The docs presented it as a working SSH credential.

## What changed

The variable stays documented everywhere it was, annotated with the 0.5.6 behavior change rather than deleted — readers who find it in an existing deployment still need to know what it does and why their password login stopped working.

- `phala-cloud/cvm/set-secure-environment-variables.mdx` — Root Access table entry now notes that 0.5.6 and later disable SSH password login.
- `phala-cloud/networking/specifications.mdx` — same note on the SSH Access table entry.
- `phala-cloud/networking/enable-ssh-access.mdx` — the SSH Authorization description now mentions public keys only, with a warning explaining the password situation; the Code Update instructions for existing CVMs point at `DSTACK_ROOT_PUBLIC_KEY`.
- `phala-cloud/troubleshooting/troubleshooting.mdx` — password login is now its own checklist entry.

## Note

Documentation only, no behavior change. The pre-launch script still honours `DSTACK_ROOT_PASSWORD`. The deploy form stops offering it in Phala-Network/phala-cloud-monorepo#1946.