### PR TITLE
docs: answer how disk encryption works, and name its limit

### DIFF
--- a/dstack/faqs.mdx
+++ b/dstack/faqs.mdx
@@ -30,8 +30,13 @@ Reference: https://github.com/Dstack-TEE/dstack/blob/master/docs/deployment.md
 
 ## How does the current data encryption system work?
 
-The system uses Linux's built-in LUKS (Linux Unified Key Setup) for disk encryption:\
-Reference: https://github.com/Dstack-TEE/dstack/blob/master/tdxctl/src/fde\_setup.rs#L437-L442
+The CVM data disk is a LUKS2 volume encrypted with `aes-xts-plain64`. The guest creates it on first boot and unlocks it on every boot after that.
+
+The key comes from KMS, which releases it only after the CVM's attestation passes the app's on-chain authorization. KMS derives it from its root key over the app ID and instance ID, so each instance gets a distinct key that exists only inside the CVM. The host holds ciphertext and never sees the key.
+
+LUKS encrypts the disk but does not authenticate it, so detecting a modified block is the filesystem's job. The default `zfs` checksums every block and fails the read. `ext4` checksums metadata but not file data.
+
+Reference: [`dstack-util/src/system_setup.rs`](https://github.com/Dstack-TEE/dstack/blob/next/dstack/dstack-util/src/system_setup.rs)
 
 ## Where is the deployment function located in the Dstack-TEE codebase, and can it be integrated with custom tools?
 

--- a/phala-cloud/phala-cloud-cli/deploy.mdx
+++ b/phala-cloud/phala-cloud-cli/deploy.mdx
@@ -40,7 +40,7 @@ Deploy new CVM or update existing one
 | ------ | ----------- |
 | `--debug` | Enable debug logging |
 | `--disk-size <value>` | Disk size with unit (e.g., 50G, default: 40GB) |
-| `--fs <value>` | Filesystem type (ext4 or zfs, default: zfs) |
+| `--fs <value>` | Filesystem for the data disk: zfs (default) or ext4. ext4 has lower I/O overhead; only zfs detects a modified block on the encrypted disk. |
 | `--image <value>` | OS image version (auto-selected if omitted) |
 | `--node-id <value>` | Node ID (auto-selected if omitted) |
 | `--kms-contract <value>` | KMS contract address |

--- a/phala-cloud/production-checklist.mdx
+++ b/phala-cloud/production-checklist.mdx
@@ -16,7 +16,7 @@ Make sure your application can handle being stopped and started at any time. Avo
 
 ### 1.2. Persist data on volumes
 
-Use [Docker volumes](https://docs.docker.com/reference/compose-file/services/#volumes) for any data that needs to persist across restarts or upgrades. Write files (databases, user uploads, etc.) to a mounted volume rather than the container’s ephemeral filesystem. Phala Cloud preserves these volumes and encrypts the data at rest, so restarting or upgrading your CVM will not lose your stored data.
+Use [Docker volumes](https://docs.docker.com/reference/compose-file/services/#volumes) for any data that needs to persist across restarts or upgrades. Write files (databases, user uploads, etc.) to a mounted volume rather than the container’s ephemeral filesystem. Phala Cloud preserves these volumes and encrypts the data at rest, so restarting or upgrading your CVM will not lose your stored data. Keep the default `zfs` storage filesystem, which also detects a modified block on the disk.
 
 Be sure to configure the volume in your docker-compose.yml to capture the right directories.
 </Step>

--- a/phala-cloud/references/terraform-provider/app-resource.mdx
+++ b/phala-cloud/references/terraform-provider/app-resource.mdx
@@ -66,7 +66,7 @@ resource "phala_app" "web" {
 |-----------|------|-------------|
 | `disk_size` | Number | Disk size in GB. Can only grow — shrink attempts are rejected by the provider. |
 | `replicas` | Number | Desired replica count. All replicas share the same compose, env, and settings. |
-| `storage_fs` | String | Storage filesystem: `zfs` or `ext4`. **Immutable after create** — changing forces replacement. |
+| `storage_fs` | String | Filesystem for the data disk: `zfs` (default) or `ext4`. `ext4` has lower I/O overhead; only `zfs` detects a modified block on the encrypted disk. **Immutable after create** — changing forces replacement. |
 | `ssh_authorized_keys` | List of String | SSH public keys injected at launch. **Force-new** — runtime mutation is not supported. |
 | `pre_launch_script` | String | Optional script content run before the CVM starts. |
 


### PR DESCRIPTION
The FAQ "How does the current data encryption system work?" answered in one sentence, then linked to `tdxctl/src/fde_setup.rs` on `master`: a path that was renamed, on a branch that no longer exists.

It now answers the question. The data disk is a LUKS2 volume using `aes-xts-plain64`. The key comes from KMS, released only after the CVM's attestation passes the app's on-chain authorization, derived over the app ID and instance ID so each instance gets a distinct key. The host holds ciphertext.

The closing paragraph names the limit: LUKS encrypts the disk but does not authenticate it, so detecting a modified block falls to the filesystem. `zfs` checksums every block and fails the read; `ext4` checksums metadata but not file data.

The three places that expose the choice give a reader a basis for making it. `--fs` and `storage_fs` were missing the default and any reason to prefer either value; both now note that ext4 has lower I/O overhead and only zfs detects a modified block. The production checklist mentions the default filesystem in the sentence where it already promises encryption at rest.

Matches Dstack-TEE/dstack#1153.